### PR TITLE
Use base64 RawStdEncoding and RawURLEncoding to improve base64 compatibility wi…

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -123,7 +123,7 @@ func ParseVLESSConfig(u *url.URL) (*models.ProxyConfig, error) {
 
 func ParseVMessConfig(u *url.URL) (*models.ProxyConfig, error) {
 	vmessStr := strings.TrimPrefix(u.String(), "vmess://")
-	decoded, err := base64.StdEncoding.DecodeString(vmessStr)
+	decoded, err := base64.RawStdEncoding.DecodeString(vmessStr)
 	if err != nil {
 		decoded, err = base64.RawURLEncoding.DecodeString(vmessStr)
 		if err != nil {
@@ -291,9 +291,9 @@ func ParseShadowsocksConfig(u *url.URL) (*models.ProxyConfig, error) {
 		Settings: make(map[string]string),
 	}
 
-	methodPass, err := base64.URLEncoding.DecodeString(u.User.String())
+	methodPass, err := base64.RawURLEncoding.DecodeString(u.User.String())
 	if err != nil {
-		methodPass, err = base64.StdEncoding.DecodeString(u.User.String())
+		methodPass, err = base64.RawStdEncoding.DecodeString(u.User.String())
 		if err != nil {
 			return nil, fmt.Errorf("error decoding method and password: %v", err)
 		}

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -73,9 +73,9 @@ func readFromURL(url string) ([]*models.ProxyConfig, error) {
 
 // readFromBase64 декодирует base64 строку и парсит содержимое
 func readFromBase64(encodedData string) ([]*models.ProxyConfig, error) {
-	decoded, err := base64.StdEncoding.DecodeString(encodedData)
+	decoded, err := base64.RawStdEncoding.DecodeString(encodedData)
 	if err != nil {
-		decoded, err = base64.URLEncoding.DecodeString(encodedData)
+		decoded, err = base64.RawURLEncoding.DecodeString(encodedData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode base64: %v", err)
 		}
@@ -407,7 +407,7 @@ func ParseSubscriptionURL(subscriptionURL string) ([]string, error) {
 	}
 
 	// Пробуем декодировать как base64
-	decoded, err := base64.StdEncoding.DecodeString(string(body))
+	decoded, err := base64.RawStdEncoding.DecodeString(string(body))
 	if err != nil {
 		// Если не base64, пробуем как обычный текст
 		return filterEmptyLinks(strings.Split(string(body), "\n")), nil


### PR DESCRIPTION
## Description of Changes

Some base64-encoded subscription URLs—especially those generated by certain backend implementations (e.g., written in PHP)—may omit trailing padding characters (`=`) from base64 strings. This leads to decoding errors such as `illegal base64 data at input byte ...` when using `base64.StdEncoding` or `base64.URLEncoding`, as they require input lengths to be multiples of 4.

To improve compatibility and robustness, this PR replaces all uses of `StdEncoding` and `URLEncoding` with `RawStdEncoding` or `RawURLEncoding`. These variants are more forgiving and can decode unpadded inputs correctly.

This change allows the system to accept a wider range of subscription sources without introducing decode errors due to strict padding requirements.

## Type of Changes

<!-- Check applicable items -->

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation improvement  
- [ ] Performance optimization  
- [ ] Other: <!-- specify type -->

## Checklist

- [x] I have performed a self-review of my code  
- [ ] I have made corresponding changes to the documentation  
- [x] I have tested changes locally