### PR TITLE
Unify decoding via AutoDecode helper to improve base64 compatibility

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,13 +1,13 @@
 package parser
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 	"xray-checker/models"
+	"xray-checker/pkg/base64"
 )
 
 func ParseProxyURL(proxyURL string) (*models.ProxyConfig, error) {
@@ -123,12 +123,9 @@ func ParseVLESSConfig(u *url.URL) (*models.ProxyConfig, error) {
 
 func ParseVMessConfig(u *url.URL) (*models.ProxyConfig, error) {
 	vmessStr := strings.TrimPrefix(u.String(), "vmess://")
-	decoded, err := base64.StdEncoding.DecodeString(vmessStr)
+	decoded, err := base64.AutoDecode(vmessStr)
 	if err != nil {
-		decoded, err = base64.RawURLEncoding.DecodeString(vmessStr)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding VMess link: %v", err)
-		}
+		return nil, fmt.Errorf("error decoding VMess link: %v", err)
 	}
 
 	var vmessConfig map[string]interface{}
@@ -291,12 +288,9 @@ func ParseShadowsocksConfig(u *url.URL) (*models.ProxyConfig, error) {
 		Settings: make(map[string]string),
 	}
 
-	methodPass, err := base64.URLEncoding.DecodeString(u.User.String())
+	methodPass, err := base64.AutoDecode(u.User.String())
 	if err != nil {
-		methodPass, err = base64.StdEncoding.DecodeString(u.User.String())
-		if err != nil {
-			return nil, fmt.Errorf("error decoding method and password: %v", err)
-		}
+		return nil, fmt.Errorf("error decoding method and password: %v", err)
 	}
 
 	parts := strings.SplitN(string(methodPass), ":", 2)

--- a/pkg/base64/base64.go
+++ b/pkg/base64/base64.go
@@ -1,0 +1,31 @@
+package base64
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// AutoDecode automatically detects whether the input uses standard or URL-safe Base64,
+// and whether it includes padding or not. It then selects the appropriate decoder
+// from the encoding/base64 package and returns the decoded bytes.
+func AutoDecode(s string) ([]byte, error) {
+	// Detect if the input is URL-safe (contains '-' or '_')
+	isURLSafe := strings.ContainsAny(s, "-_")
+
+	// Detect if the input is padded (ends with '=')
+	isPadded := strings.HasSuffix(s, "=")
+
+	var enc *base64.Encoding
+	switch {
+	case isURLSafe && isPadded:
+		enc = base64.URLEncoding
+	case isURLSafe && !isPadded:
+		enc = base64.RawURLEncoding
+	case !isURLSafe && isPadded:
+		enc = base64.StdEncoding
+	case !isURLSafe && !isPadded:
+		enc = base64.RawStdEncoding
+	}
+
+	return enc.DecodeString(s)
+}

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -1,7 +1,6 @@
 package subscription
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +14,7 @@ import (
 	"xray-checker/config"
 	"xray-checker/models"
 	"xray-checker/parser"
+	"xray-checker/pkg/base64"
 	"xray-checker/xray"
 )
 
@@ -73,12 +73,9 @@ func readFromURL(url string) ([]*models.ProxyConfig, error) {
 
 // readFromBase64 декодирует base64 строку и парсит содержимое
 func readFromBase64(encodedData string) ([]*models.ProxyConfig, error) {
-	decoded, err := base64.StdEncoding.DecodeString(encodedData)
+	decoded, err := base64.AutoDecode(encodedData)
 	if err != nil {
-		decoded, err = base64.URLEncoding.DecodeString(encodedData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode base64: %v", err)
-		}
+		return nil, fmt.Errorf("failed to decode base64: %v", err)
 	}
 
 	links := strings.Split(string(decoded), "\n")
@@ -407,7 +404,7 @@ func ParseSubscriptionURL(subscriptionURL string) ([]string, error) {
 	}
 
 	// Пробуем декодировать как base64
-	decoded, err := base64.StdEncoding.DecodeString(string(body))
+	decoded, err := base64.AutoDecode(string(body))
 	if err != nil {
 		// Если не base64, пробуем как обычный текст
 		return filterEmptyLinks(strings.Split(string(body), "\n")), nil


### PR DESCRIPTION
## Description of Changes

Replaced all base64 decoding calls with the new AutoDecode function, which automatically detects
whether the input uses standard or URL-safe Base64, and whether padding is present.

This change improves compatibility with unpadded and mixed-format inputs from external sources(e.g., Some PHP implementations remove the padding (=) from the base64-encoded part of Shadowsocket links, which can cause decoding failures.).

The AutoDecode helper simplifies logic and eliminates the need to manually choose between
RawStdEncoding, StdEncoding, URLEncoding, etc.


## Type of Changes

<!-- Check applicable items -->

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation improvement  
- [ ] Performance optimization  
- [ ] Other: <!-- specify type -->

## Checklist

- [x] I have performed a self-review of my code  
- [ ] I have made corresponding changes to the documentation  
- [x] I have tested changes locally