### PR TITLE
feat: add HTTP Header config support

### DIFF
--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -164,6 +164,10 @@ func (pc *ProxyConfig) HasHTTPUpgradeSettings() bool {
 	return pc.Type == "httpupgrade"
 }
 
+func (pc *ProxyConfig) HasTCPHTTPSettings() bool {
+	return (pc.Type == "tcp" || pc.Type == "") && pc.HeaderType == "http"
+}
+
 func (pc *ProxyConfig) GetServiceName() string {
 	if pc.ServiceName == "" {
 		return "GunService"

--- a/xray/templates/xray.json.tmpl
+++ b/xray/templates/xray.json.tmpl
@@ -202,6 +202,36 @@
       "initial_windows_size": {{.WindowsSize}}
       {{- end }}
     }
+    {{- end }}
+
+    {{- if .HasTCPHTTPSettings }},
+    "tcpSettings": {
+      "header": {
+        "type": "http",
+        "request": {
+          "version": "1.1",
+          "method": "GET",
+          "path": [
+            "{{.Path}}"
+          ],
+          "headers": {
+            "Host": [
+              "{{.Host}}"
+            ],
+            "User-Agent": [
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            ],
+            "Accept-Encoding": [
+              "gzip, deflate"
+            ],
+            "Connection": [
+              "keep-alive"
+            ],
+            "Pragma": "no-cache"
+          }
+        }
+      }
+    }
     {{- end }},
     
     "sockopt": {}


### PR DESCRIPTION
## Description of Changes

Add support for VLESS + TCP + HTTP Header configs which was previously failed to parse correctly to json and therefore checks was failing.

## Type of Changes

<!-- Check applicable items -->

- [x] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Performance optimization
- [ ] Other: <!-- specify type -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have tested changes locally
