### PR TITLE
fix: ensure proxy stable IDs are unique for distinct configs

### DIFF
--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -78,9 +78,9 @@ func (pc *ProxyConfig) GenerateStableID() string {
 	var idComponents []string
 
 	idComponents = append(idComponents, pc.Protocol)
-
 	idComponents = append(idComponents, pc.Server)
 	idComponents = append(idComponents, fmt.Sprintf("%d", pc.Port))
+	idComponents = append(idComponents, pc.Name)
 
 	switch pc.Protocol {
 	case "vless", "vmess":
@@ -94,6 +94,14 @@ func (pc *ProxyConfig) GenerateStableID() string {
 		if pc.Protocol == "shadowsocks" && pc.Method != "" {
 			idComponents = append(idComponents, pc.Method)
 		}
+	}
+
+	if pc.Flow != "" {
+		idComponents = append(idComponents, pc.Flow)
+	}
+
+	if pc.Encryption != "" {
+		idComponents = append(idComponents, pc.Encryption)
 	}
 
 	if pc.SNI != "" {
@@ -110,6 +118,38 @@ func (pc *ProxyConfig) GenerateStableID() string {
 
 	if pc.PublicKey != "" {
 		idComponents = append(idComponents, pc.PublicKey)
+	}
+
+	if pc.Fingerprint != "" {
+		idComponents = append(idComponents, pc.Fingerprint)
+	}
+
+	if pc.ShortID != "" {
+		idComponents = append(idComponents, pc.ShortID)
+	}
+
+	if pc.HeaderType != "" {
+		idComponents = append(idComponents, pc.HeaderType)
+	}
+
+	if pc.Path != "" {
+		idComponents = append(idComponents, pc.Path)
+	}
+
+	if pc.Host != "" {
+		idComponents = append(idComponents, pc.Host)
+	}
+
+	if pc.Mode != "" {
+		idComponents = append(idComponents, pc.Mode)
+	}
+
+	if pc.ServiceName != "" {
+		idComponents = append(idComponents, pc.ServiceName)
+	}
+
+	if len(pc.ALPN) > 0 {
+		idComponents = append(idComponents, strings.Join(pc.ALPN, ","))
 	}
 
 	idString := strings.Join(idComponents, "|")

--- a/xray/utils.go
+++ b/xray/utils.go
@@ -1,16 +1,25 @@
 package xray
 
 import (
+	"fmt"
 	"xray-checker/models"
 )
 
 func PrepareProxyConfigs(proxies []*models.ProxyConfig) {
+	seenIDs := make(map[string]int, len(proxies))
+
 	for i := range proxies {
 		proxies[i].Index = i
 
-		if proxies[i].StableID == "" {
-			proxies[i].StableID = proxies[i].GenerateStableID()
+		baseID := proxies[i].GenerateStableID()
+		seenIDs[baseID]++
+
+		if seenIDs[baseID] == 1 {
+			proxies[i].StableID = baseID
+			continue
 		}
+
+		proxies[i].StableID = fmt.Sprintf("%s-%d", baseID, seenIDs[baseID])
 	}
 }
 
@@ -19,31 +28,25 @@ func IsConfigsEqual(old, new []*models.ProxyConfig) bool {
 		return false
 	}
 
-	oldMap := make(map[string]bool)
-	newMap := make(map[string]bool)
+	oldCounts := make(map[string]int, len(old))
+	newCounts := make(map[string]int, len(new))
 
 	for _, cfg := range old {
-		if cfg.StableID == "" {
-			cfg.StableID = cfg.GenerateStableID()
-		}
-		oldMap[cfg.StableID] = true
+		oldCounts[cfg.GenerateStableID()]++
 	}
 
 	for _, cfg := range new {
-		if cfg.StableID == "" {
-			cfg.StableID = cfg.GenerateStableID()
-		}
-		newMap[cfg.StableID] = true
+		newCounts[cfg.GenerateStableID()]++
 	}
 
-	for id := range oldMap {
-		if !newMap[id] {
+	for id, count := range oldCounts {
+		if newCounts[id] != count {
 			return false
 		}
 	}
 
-	for id := range newMap {
-		if !oldMap[id] {
+	for id, count := range newCounts {
+		if oldCounts[id] != count {
 			return false
 		}
 	}


### PR DESCRIPTION
## Description of Changes

Fix proxy identity generation so distinct proxy configurations no longer receive the same `stableId`.

The previous `stableId` generation used only a subset of proxy fields, which caused collisions for configs that shared the same
protocol/server/port/UUID/public key but differed in meaningful transport fields such as Reality fingerprint. This broke the
dashboard because Alpine uses `stableId` as the `x-for` key, resulting in duplicate key warnings and missing server cards.

This PR:
- expands `GenerateStableID()` to include additional identity-defining fields
- ensures runtime `stableId` values remain unique even if two entries are otherwise identical
- updates config equality checks to compare duplicate counts correctly instead of treating IDs as a set

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Performance optimization
- [ ] Other: identity handling

## Related Issues

Fixes #

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have tested changes locally