### PR TITLE
fix: make `StableID` unique to prevent duplicate key errors

### DIFF
--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -112,6 +112,12 @@ func (pc *ProxyConfig) GenerateStableID() string {
 		idComponents = append(idComponents, pc.PublicKey)
 	}
 
+	if pc.Name != "" {
+		idComponents = append(idComponents, pc.Name)
+	}
+
+	idComponents = append(idComponents, fmt.Sprintf("idx:%d", pc.Index))
+
 	idString := strings.Join(idComponents, "|")
 
 	hash := sha256.Sum256([]byte(idString))


### PR DESCRIPTION
Adds `Name` and `Index` to the `StableID` computation.

This fixes duplicate `:key` warnings and the `Cannot read properties of undefined (reading 'after')` error in Alpine.js when multiple proxies have very similar or identical configurations.

## Description of Changes
- Improved `GenerateStableID()` method to include proxy `Name` and `Index`
- Eliminates duplicate key errors in the frontend

## Type of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Performance optimization
- [ ] Other

## Related Issues
#141

## Checklist
- [x] I have performed a self-review of my code
- [x] I have tested changes locally
- [ ] I have made corresponding changes to the documentation (not needed)