### PR TITLE
fix: include fingerprint in stable ID generation

### DIFF
--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -112,6 +112,10 @@ func (pc *ProxyConfig) GenerateStableID() string {
 		idComponents = append(idComponents, pc.PublicKey)
 	}
 
+	if pc.Fingerprint != "" {
+		idComponents = append(idComponents, pc.Fingerprint)
+	}
+
 	idString := strings.Join(idComponents, "|")
 
 	hash := sha256.Sum256([]byte(idString))


### PR DESCRIPTION
## Description of Changes

The `fp` (fingerprint) parameter was not included in `stableId` generation, causing configs that differ only by `fp` to receive identical stable IDs. This fix ensures `fp` is included in the hash input alongside other identifying parameters.

## Type of Changes

- [x] Bug fix

## Related Issues

Fixes #157

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have tested changes locally