### PR TITLE
T2: stop metrics blinking to 0 on subscription update (#148)

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -78,12 +78,11 @@ func (pc *ProxyChecker) CheckProxy(proxy *models.ProxyConfig) {
 	pc.checkProxyInternal(proxy, 0, false)
 }
 
-func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGeneration uint64, checkGeneration bool) {
-	if proxy.StableID == "" {
-		proxy.StableID = proxy.GenerateStableID()
-	}
-
-	metricKey := fmt.Sprintf("%s|%s:%d|%s|%s|%s",
+// proxyMetricKey builds the in-memory map key for a proxy. The first four
+// "|"-separated fields (protocol, address, name, sub_name) match the Prometheus
+// label set, so ClearMetrics/ReconcileMetrics can derive the series labels from it.
+func proxyMetricKey(proxy *models.ProxyConfig) string {
+	return fmt.Sprintf("%s|%s:%d|%s|%s|%s",
 		proxy.Protocol,
 		proxy.Server,
 		proxy.Port,
@@ -91,6 +90,14 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 		proxy.SubName,
 		proxy.StableID,
 	)
+}
+
+func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGeneration uint64, checkGeneration bool) {
+	if proxy.StableID == "" {
+		proxy.StableID = proxy.GenerateStableID()
+	}
+
+	metricKey := proxyMetricKey(proxy)
 
 	isGenerationValid := func() bool {
 		if !checkGeneration {
@@ -335,12 +342,57 @@ func (pc *ProxyChecker) ClearMetrics() {
 	})
 }
 
+// UpdateProxies swaps in a new proxy set and bumps the generation. It deliberately
+// does NOT clear metrics: doing so used to leave /metrics empty (every proxy "down")
+// for up to PROXY_CHECK_INTERVAL until the next scheduled check (#148). The old series
+// are kept so existing proxies never blink; the caller should run an immediate check
+// and then ReconcileMetrics to drop series for proxies that no longer exist.
 func (pc *ProxyChecker) UpdateProxies(newProxies []*models.ProxyConfig) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	atomic.AddUint64(&pc.generation, 1)
-	pc.ClearMetrics()
 	pc.proxies = newProxies
+}
+
+// ReconcileMetrics removes status/latency series and in-memory entries that belong
+// to proxies no longer present in the current set. It is meant to run after an
+// immediate post-update check has populated metrics for the new set, so surviving
+// proxies keep their freshly-refreshed values and only stale ones are pruned.
+func (pc *ProxyChecker) ReconcileMetrics() {
+	pc.mu.RLock()
+	currentKeys := make(map[string]struct{}, len(pc.proxies))
+	currentLabels := make(map[string]struct{}, len(pc.proxies))
+	for _, proxy := range pc.proxies {
+		if proxy.StableID == "" {
+			proxy.StableID = proxy.GenerateStableID()
+		}
+		key := proxyMetricKey(proxy)
+		currentKeys[key] = struct{}{}
+		// label tuple = protocol|address|name|sub_name (first 4 key fields)
+		currentLabels[fmt.Sprintf("%s|%s:%d|%s|%s", proxy.Protocol, proxy.Server, proxy.Port, proxy.Name, proxy.SubName)] = struct{}{}
+	}
+	pc.mu.RUnlock()
+
+	pc.currentMetrics.Range(func(k, _ interface{}) bool {
+		metricKey := k.(string)
+		if _, ok := currentKeys[metricKey]; ok {
+			return true
+		}
+		parts := strings.Split(metricKey, "|")
+		if len(parts) >= 4 {
+			// Only delete the Prometheus series if no surviving proxy shares the
+			// same label tuple (guards against same-label collisions removing a
+			// still-present proxy's series).
+			labelTuple := strings.Join(parts[0:4], "|")
+			if _, used := currentLabels[labelTuple]; !used {
+				metrics.DeleteProxyStatus(parts[0], parts[1], parts[2], parts[3])
+				metrics.DeleteProxyLatency(parts[0], parts[1], parts[2], parts[3])
+			}
+		}
+		pc.currentMetrics.Delete(k)
+		pc.latencyMetrics.Delete(k)
+		return true
+	})
 }
 
 func (pc *ProxyChecker) CheckAllProxies() {
@@ -375,14 +427,7 @@ func (pc *ProxyChecker) GetProxyStatus(name string) (bool, time.Duration, error)
 				proxy.StableID = proxy.GenerateStableID()
 			}
 
-			metricKey = fmt.Sprintf("%s|%s:%d|%s|%s|%s",
-				proxy.Protocol,
-				proxy.Server,
-				proxy.Port,
-				proxy.Name,
-				proxy.SubName,
-				proxy.StableID,
-			)
+			metricKey = proxyMetricKey(proxy)
 			break
 		}
 	}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1,0 +1,89 @@
+package checker
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"xray-checker/metrics"
+	"xray-checker/models"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+var metricsOnce sync.Once
+
+func ensureMetrics() { metricsOnce.Do(func() { metrics.InitMetrics("") }) }
+
+func mkProxy(server, name, stableID string) *models.ProxyConfig {
+	return &models.ProxyConfig{
+		Protocol: "vless",
+		Server:   server,
+		Port:     443,
+		Name:     name,
+		SubName:  "sub",
+		StableID: stableID,
+	}
+}
+
+// recordUp mimics what checkProxyInternal writes on a successful check.
+func recordUp(pc *ProxyChecker, p *models.ProxyConfig, lat time.Duration) {
+	addr := fmt.Sprintf("%s:%d", p.Server, p.Port)
+	metrics.RecordProxyStatus(p.Protocol, addr, p.Name, p.SubName, 1)
+	metrics.RecordProxyLatency(p.Protocol, addr, p.Name, p.SubName, lat)
+	pc.currentMetrics.Store(proxyMetricKey(p), true)
+	pc.latencyMetrics.Store(proxyMetricKey(p), lat)
+}
+
+// Reproduces the #148 scenario: a subscription update must not blank out metrics,
+// and after the post-update check, series for removed proxies must be pruned.
+func TestUpdateProxiesKeepsMetricsAndReconcilePrunesStale(t *testing.T) {
+	ensureMetrics()
+
+	a := mkProxy("1.1.1.1", "A", "ida")
+	b := mkProxy("2.2.2.2", "B", "idb")
+	pc := NewProxyChecker([]*models.ProxyConfig{a, b}, 10000, "", 5, "", "", 5, 1, "ip")
+
+	// Initial check populated A and B.
+	recordUp(pc, a, 100*time.Millisecond)
+	recordUp(pc, b, 200*time.Millisecond)
+	if got := testutil.CollectAndCount(metrics.GetProxyStatusMetric()); got != 2 {
+		t.Fatalf("expected 2 status series after initial check, got %d", got)
+	}
+
+	// Subscription update: B removed, C added.
+	c := mkProxy("3.3.3.3", "C", "idc")
+	pc.UpdateProxies([]*models.ProxyConfig{a, c})
+
+	// UpdateProxies must NOT clear existing series (the #148 fix): A and B remain,
+	// so /metrics never goes empty between the update and the next check.
+	if got := testutil.CollectAndCount(metrics.GetProxyStatusMetric()); got != 2 {
+		t.Fatalf("UpdateProxies must not clear metrics; expected 2 series, got %d", got)
+	}
+	if v := testutil.ToFloat64(metrics.GetProxyStatusMetric().WithLabelValues("vless", "1.1.1.1:443", "A", "sub")); v != 1 {
+		t.Fatalf("surviving proxy A must keep status 1 across the update, got %v", v)
+	}
+
+	// Immediate post-update check refreshes A and populates C.
+	recordUp(pc, a, 120*time.Millisecond)
+	recordUp(pc, c, 300*time.Millisecond)
+
+	pc.ReconcileMetrics()
+
+	// After reconcile: A and C present, B pruned.
+	if got := testutil.CollectAndCount(metrics.GetProxyStatusMetric()); got != 2 {
+		t.Fatalf("after reconcile expected 2 series (A,C), got %d", got)
+	}
+	if _, ok := pc.currentMetrics.Load(proxyMetricKey(b)); ok {
+		t.Errorf("removed proxy B should be pruned from currentMetrics")
+	}
+	if _, ok := pc.latencyMetrics.Load(proxyMetricKey(b)); ok {
+		t.Errorf("removed proxy B should be pruned from latencyMetrics")
+	}
+	for _, p := range []*models.ProxyConfig{a, c} {
+		if _, ok := pc.currentMetrics.Load(proxyMetricKey(p)); !ok {
+			t.Errorf("proxy %s should remain in currentMetrics", p.Name)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pires/go-proxyproto v0.11.0 // indirect

--- a/main.go
+++ b/main.go
@@ -151,6 +151,12 @@ func main() {
 			if !xray.IsConfigsEqual(*proxyConfigs, newConfigs) {
 				if err := updateConfiguration(newConfigs, proxyConfigs, xrayRunner, proxyChecker); err != nil {
 					logger.Error("Error updating configuration: %v", err)
+				} else {
+					// Immediately re-check the new proxy set so /metrics is repopulated
+					// right away instead of staying empty until the next scheduled check
+					// (up to PROXY_CHECK_INTERVAL), then drop series for removed proxies.
+					runCheckIteration()
+					proxyChecker.ReconcileMetrics()
 				}
 			} else {
 				logger.Info("Subscriptions checked, no changes")


### PR DESCRIPTION
## Summary

Fixes **#148**: on every subscription update, `/metrics` returned no `xray_proxy_*` series (so every proxy looked **down**) for up to `PROXY_CHECK_INTERVAL` (default **300s**).

**Root cause:** `checker.UpdateProxies()` called `ClearMetrics()` immediately and then waited for the next scheduled `CheckAllProxies` tick to repopulate (`main.go` `updateConfiguration` → `UpdateProxies`).

## Fix — double-buffer + immediate re-check + reconcile

- **`UpdateProxies` no longer clears metrics** — it only swaps the proxy set and bumps the generation, so existing proxies keep their last values (no blink).
- **`updateConfiguration` runs an immediate check** right after the swap, so the new set is populated without waiting for the next tick.
- **New `ReconcileMetrics()`** prunes status/latency series + map entries only for proxies that no longer exist — guarded against same-label collisions so a surviving proxy's series is never deleted.
- Extracted `proxyMetricKey()` helper (used by `checkProxyInternal`, `GetProxyStatus`, `ReconcileMetrics`) so the key format lives in one place.

## Tests

**Unit** (`checker/checker_test.go`): asserts `UpdateProxies` does not clear existing series, surviving proxies keep status 1 across the update, and `ReconcileMetrics` prunes only removed proxies.

**Live** — ran against a real 114-proxy subscription, then swapped it for a 57-proxy subset mid-run while sampling the series count every second:

```
INITIAL READY: 114 series
SWAPPED to 57-link subscription
t+3s:  count=114    t+9s:  count=114
t+12s: count=57     ...    t+54s: count=57
MIN series count after swap: 57   (0 => blink bug; ~57 => fixed)
final: 57 series, all value=1, status {total:57, online:57, offline:0}
```

Count went **114 → 57 directly, never 0** (old code would drop to 0 on `ClearMetrics`), survivors stayed online, removed proxies were pruned, and the new set was populated immediately rather than after the next 300s tick.

`go build` / `go vet` / `gofmt -l` / `go test ./...` clean. Based on top of merged #161.

