### PR TITLE
Round 2 / B1: unique stableID per endpoint (fixes #149, #153, #141)

### DIFF
--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -106,19 +106,23 @@ func (pc *ProxyConfig) GenerateStableID() string {
 	write("server", pc.Server)
 	write("port", strconv.Itoa(pc.Port))
 
+	// Low-entropy, human-chosen secrets (trojan/shadowsocks password, hysteria auth)
+	// are deliberately NOT hashed: stableID is a PUBLIC identifier (API, badges) and a
+	// 64-bit truncated hash of a weak password alongside otherwise-known fields could
+	// be brute-forced offline. The UUID is kept: it is a high-entropy (122-bit) random
+	// identifier, so its hash is not brute-forceable, and it is a meaningful
+	// discriminator when one endpoint serves several users/routes that differ only by
+	// UUID (e.g. vless route-id setups). The AssignStableIDs tiebreaker separates any
+	// configs that still collide after excluding the low-entropy secrets.
 	switch pc.Protocol {
 	case "vless", "vmess":
 		write("uuid", pc.UUID)
 		if pc.Protocol == "vmess" {
 			write("alterId", strconv.Itoa(pc.GetAlterId()))
 		}
-	case "trojan":
-		write("password", pc.Password)
 	case "shadowsocks":
-		write("password", pc.Password)
 		write("method", pc.Method)
 	case "hysteria":
-		write("auth", pc.HysteriaAuth)
 		write("ports", pc.HysteriaPorts)
 		write("obfs", pc.HysteriaObfs)
 	}

--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -87,57 +89,104 @@ func (pc *ProxyConfig) Validate() error {
 	return nil
 }
 
+// GenerateStableID returns a 16-hex content hash that identifies a proxy by its
+// connection parameters. Every field that affects the actual connection is included
+// so endpoints differing only in transport details (path, host, fp, shortId, flow,
+// alpn, ...) get distinct IDs. Name/SubName are deliberately excluded so that
+// renaming a server in the panel does NOT change its ID; same-connection configs
+// that differ only by name are separated afterwards by AssignStableIDs.
 func (pc *ProxyConfig) GenerateStableID() string {
-	var idComponents []string
+	h := sha256.New()
+	// length-framed components so values containing the delimiter stay unambiguous
+	write := func(key, val string) {
+		fmt.Fprintf(h, "%s=%d:%s;", key, len(val), val)
+	}
 
-	idComponents = append(idComponents, pc.Protocol)
-
-	idComponents = append(idComponents, pc.Server)
-	idComponents = append(idComponents, fmt.Sprintf("%d", pc.Port))
+	write("protocol", pc.Protocol)
+	write("server", pc.Server)
+	write("port", strconv.Itoa(pc.Port))
 
 	switch pc.Protocol {
 	case "vless", "vmess":
-		if pc.UUID != "" {
-			idComponents = append(idComponents, pc.UUID)
+		write("uuid", pc.UUID)
+		if pc.Protocol == "vmess" {
+			write("alterId", strconv.Itoa(pc.GetAlterId()))
 		}
-	case "trojan", "shadowsocks":
-		if pc.Password != "" {
-			idComponents = append(idComponents, pc.Password)
-		}
-		if pc.Protocol == "shadowsocks" && pc.Method != "" {
-			idComponents = append(idComponents, pc.Method)
-		}
+	case "trojan":
+		write("password", pc.Password)
+	case "shadowsocks":
+		write("password", pc.Password)
+		write("method", pc.Method)
 	case "hysteria":
-		if pc.HysteriaAuth != "" {
-			idComponents = append(idComponents, pc.HysteriaAuth)
+		write("auth", pc.HysteriaAuth)
+		write("ports", pc.HysteriaPorts)
+		write("obfs", pc.HysteriaObfs)
+	}
+
+	write("encryption", pc.Encryption)
+	write("flow", pc.Flow)
+	write("security", pc.Security)
+	write("sni", pc.SNI)
+	write("fp", pc.Fingerprint)
+	write("pbk", pc.PublicKey)
+	write("sid", pc.ShortID)
+
+	alpn := append([]string(nil), pc.ALPN...)
+	sort.Strings(alpn)
+	write("alpn", strings.Join(alpn, ","))
+
+	write("net", pc.Type)
+	write("headerType", pc.HeaderType)
+	write("host", pc.Host)
+	write("path", pc.Path)
+	write("serviceName", pc.ServiceName)
+	write("mode", pc.Mode)
+	write("rawXhttp", pc.RawXhttpSettings)
+
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// AssignStableIDs sets the final StableID for every proxy in the set. Proxies with
+// identical connection parameters (same GenerateStableID) are separated with a
+// deterministic suffix derived from a stable ordering (Name, then SubName, then
+// Index), so the resulting IDs are unique and stable across subscription reordering.
+// The first member of each colliding group keeps the bare hash, so single configs
+// (the common case) are unaffected.
+func AssignStableIDs(proxies []*ProxyConfig) {
+	groups := make(map[string][]*ProxyConfig)
+	order := make([]string, 0)
+	for _, p := range proxies {
+		base := p.GenerateStableID()
+		if _, seen := groups[base]; !seen {
+			order = append(order, base)
+		}
+		groups[base] = append(groups[base], p)
+	}
+
+	for _, base := range order {
+		group := groups[base]
+		if len(group) == 1 {
+			group[0].StableID = base
+			continue
+		}
+		sort.SliceStable(group, func(i, j int) bool {
+			if group[i].Name != group[j].Name {
+				return group[i].Name < group[j].Name
+			}
+			if group[i].SubName != group[j].SubName {
+				return group[i].SubName < group[j].SubName
+			}
+			return group[i].Index < group[j].Index
+		})
+		for n, p := range group {
+			if n == 0 {
+				p.StableID = base
+				continue
+			}
+			sum := sha256.Sum256([]byte(base + "::" + strconv.Itoa(n)))
+			p.StableID = hex.EncodeToString(sum[:])[:16]
 		}
 	}
-
-	if pc.SNI != "" {
-		idComponents = append(idComponents, pc.SNI)
-	}
-
-	if pc.Type != "" {
-		idComponents = append(idComponents, pc.Type)
-	}
-
-	if pc.Security != "" {
-		idComponents = append(idComponents, pc.Security)
-	}
-
-	if pc.PublicKey != "" {
-		idComponents = append(idComponents, pc.PublicKey)
-	}
-
-	if pc.Fingerprint != "" {
-		idComponents = append(idComponents, pc.Fingerprint)
-	}
-
-	idString := strings.Join(idComponents, "|")
-
-	hash := sha256.Sum256([]byte(idString))
-
-	return hex.EncodeToString(hash[:])[:16]
 }
 
 func (pc *ProxyConfig) GetTransportType() string {

--- a/models/proxy_config_test.go
+++ b/models/proxy_config_test.go
@@ -35,7 +35,7 @@ func TestGenerateStableID_DistinguishesConnectionFields(t *testing.T) {
 		"encryption": func(p *ProxyConfig) { p.Encryption = "none" },
 		"server":     func(p *ProxyConfig) { p.Server = "other.com" },
 		"port":       func(p *ProxyConfig) { p.Port = 8443 },
-		"uuid":       func(p *ProxyConfig) { p.UUID = "11111111-1111-1111-1111-111111111111" },
+		"uuid":       func(p *ProxyConfig) { p.UUID = "11111111-1111-1111-1111-111111111111" }, // vless route-id: same node, different exit
 		"publicKey":  func(p *ProxyConfig) { p.PublicKey = "PBK2" },
 		"alpn":       func(p *ProxyConfig) { p.ALPN = []string{"h2"} },
 	}
@@ -62,6 +62,23 @@ func TestGenerateStableID_IgnoresNameAndIndex(t *testing.T) {
 		if got := p.GenerateStableID(); got != base {
 			t.Errorf("%s must not affect stableID: %s != %s", name, got, base)
 		}
+	}
+}
+
+// stableID is public, so it must NOT change with low-entropy, human-chosen secrets
+// (trojan/shadowsocks password, hysteria auth) — a truncated hash of those could be
+// brute-forced. (The high-entropy UUID is kept; see DistinguishesConnectionFields.)
+func TestGenerateStableID_ExcludesSecrets(t *testing.T) {
+	tr := &ProxyConfig{Protocol: "trojan", Server: "s.example.com", Port: 443, Password: "secret-one", Name: "T"}
+	tr2 := &ProxyConfig{Protocol: "trojan", Server: "s.example.com", Port: 443, Password: "secret-two", Name: "T"}
+	if tr.GenerateStableID() != tr2.GenerateStableID() {
+		t.Errorf("trojan password (secret) must not affect stableID")
+	}
+
+	hy := &ProxyConfig{Protocol: "hysteria", Server: "h.example.com", Port: 443, HysteriaAuth: "auth-one", Name: "H"}
+	hy2 := &ProxyConfig{Protocol: "hysteria", Server: "h.example.com", Port: 443, HysteriaAuth: "auth-two", Name: "H"}
+	if hy.GenerateStableID() != hy2.GenerateStableID() {
+		t.Errorf("hysteria auth (secret) must not affect stableID")
 	}
 }
 

--- a/models/proxy_config_test.go
+++ b/models/proxy_config_test.go
@@ -1,0 +1,148 @@
+package models
+
+import "testing"
+
+func baseProxy() *ProxyConfig {
+	return &ProxyConfig{
+		Protocol:    "vless",
+		Server:      "example.com",
+		Port:        443,
+		UUID:        "00000000-0000-0000-0000-000000000000",
+		Security:    "reality",
+		Type:        "tcp",
+		SNI:         "example.com",
+		PublicKey:   "PBK",
+		ShortID:     "sid1",
+		Flow:        "xtls-rprx-vision",
+		Fingerprint: "chrome",
+		Name:        "Server A",
+	}
+}
+
+// Every connection-distinguishing field must change the stableID.
+func TestGenerateStableID_DistinguishesConnectionFields(t *testing.T) {
+	base := baseProxy().GenerateStableID()
+	cases := map[string]func(*ProxyConfig){
+		"fp":         func(p *ProxyConfig) { p.Fingerprint = "firefox" },
+		"path":       func(p *ProxyConfig) { p.Path = "/other" },
+		"host":       func(p *ProxyConfig) { p.Host = "h2.example.com" },
+		"shortId":    func(p *ProxyConfig) { p.ShortID = "sid2" },
+		"flow":       func(p *ProxyConfig) { p.Flow = "" },
+		"sni":        func(p *ProxyConfig) { p.SNI = "other.com" },
+		"security":   func(p *ProxyConfig) { p.Security = "tls" },
+		"type":       func(p *ProxyConfig) { p.Type = "ws" },
+		"headerType": func(p *ProxyConfig) { p.HeaderType = "http" },
+		"encryption": func(p *ProxyConfig) { p.Encryption = "none" },
+		"server":     func(p *ProxyConfig) { p.Server = "other.com" },
+		"port":       func(p *ProxyConfig) { p.Port = 8443 },
+		"uuid":       func(p *ProxyConfig) { p.UUID = "11111111-1111-1111-1111-111111111111" },
+		"publicKey":  func(p *ProxyConfig) { p.PublicKey = "PBK2" },
+		"alpn":       func(p *ProxyConfig) { p.ALPN = []string{"h2"} },
+	}
+	for name, mut := range cases {
+		p := baseProxy()
+		mut(p)
+		if got := p.GenerateStableID(); got == base {
+			t.Errorf("changing %s must change stableID (still %s)", name, got)
+		}
+	}
+}
+
+// Name/SubName/Index must NOT affect the stableID (renames keep monitors stable).
+func TestGenerateStableID_IgnoresNameAndIndex(t *testing.T) {
+	base := baseProxy().GenerateStableID()
+	cases := map[string]func(*ProxyConfig){
+		"Name":    func(p *ProxyConfig) { p.Name = "Totally Different Name" },
+		"SubName": func(p *ProxyConfig) { p.SubName = "another-sub" },
+		"Index":   func(p *ProxyConfig) { p.Index = 99 },
+	}
+	for name, mut := range cases {
+		p := baseProxy()
+		mut(p)
+		if got := p.GenerateStableID(); got != base {
+			t.Errorf("%s must not affect stableID: %s != %s", name, got, base)
+		}
+	}
+}
+
+func TestGenerateStableID_AlpnOrderIndependent(t *testing.T) {
+	a := baseProxy()
+	a.ALPN = []string{"h2", "http/1.1"}
+	b := baseProxy()
+	b.ALPN = []string{"http/1.1", "h2"}
+	if a.GenerateStableID() != b.GenerateStableID() {
+		t.Errorf("ALPN order should not affect stableID")
+	}
+}
+
+func mk(name, path, fp string) *ProxyConfig {
+	p := baseProxy()
+	p.Name = name
+	p.Path = path
+	p.Fingerprint = fp
+	return p
+}
+
+// All IDs unique across the cluster cases: path-only (#149), fp-only (#157),
+// same-connection-diff-name, and true duplicates.
+func TestAssignStableIDs_AllUnique(t *testing.T) {
+	proxies := []*ProxyConfig{
+		mk("A", "/p1", "chrome"),
+		mk("B", "/p2", "chrome"),  // differs by path (#149)
+		mk("C", "/p1", "firefox"), // differs by fp (#157)
+		mk("Dup1", "/p1", "chrome"),
+		mk("Dup2", "/p1", "chrome"), // same connection as A, distinct name
+		mk("A", "/p1", "chrome"),    // true duplicate of A (incl name)
+	}
+	for i, p := range proxies {
+		p.Index = i
+	}
+	AssignStableIDs(proxies)
+
+	seen := map[string]int{}
+	for _, p := range proxies {
+		if p.StableID == "" {
+			t.Fatal("empty stableID after AssignStableIDs")
+		}
+		seen[p.StableID]++
+	}
+	if len(seen) != len(proxies) {
+		t.Errorf("expected %d unique IDs, got %d: %v", len(proxies), len(seen), seen)
+	}
+}
+
+// Same-connection-different-name configs get the same ID regardless of input order.
+func TestAssignStableIDs_DeterministicAcrossReorder(t *testing.T) {
+	build := func() []*ProxyConfig {
+		return []*ProxyConfig{
+			mk("A", "/p1", "chrome"),    // group X (members: A, Dup1, Dup2)
+			mk("Dup1", "/p1", "chrome"), // group X
+			mk("Dup2", "/p1", "chrome"), // group X
+			mk("B", "/p2", "chrome"),    // group Y (singleton)
+		}
+	}
+
+	forward := build()
+	for i, p := range forward {
+		p.Index = i
+	}
+	AssignStableIDs(forward)
+	idByName := map[string]string{}
+	for _, p := range forward {
+		idByName[p.Name] = p.StableID
+	}
+
+	rev := build()
+	for i, j := 0, len(rev)-1; i < j; i, j = i+1, j-1 {
+		rev[i], rev[j] = rev[j], rev[i]
+	}
+	for i, p := range rev {
+		p.Index = i
+	}
+	AssignStableIDs(rev)
+	for _, p := range rev {
+		if idByName[p.Name] != p.StableID {
+			t.Errorf("%s got different ID across reorder: %s vs %s", p.Name, idByName[p.Name], p.StableID)
+		}
+	}
+}

--- a/xray/utils.go
+++ b/xray/utils.go
@@ -7,11 +7,10 @@ import (
 func PrepareProxyConfigs(proxies []*models.ProxyConfig) {
 	for i := range proxies {
 		proxies[i].Index = i
-
-		if proxies[i].StableID == "" {
-			proxies[i].StableID = proxies[i].GenerateStableID()
-		}
 	}
+	// Assign final StableIDs over the whole set so that identical-connection configs
+	// are separated deterministically (see models.AssignStableIDs).
+	models.AssignStableIDs(proxies)
 }
 
 func IsConfigsEqual(old, new []*models.ProxyConfig) bool {
@@ -19,21 +18,18 @@ func IsConfigsEqual(old, new []*models.ProxyConfig) bool {
 		return false
 	}
 
+	// Compare on the base content hash directly (not the assigned StableID, which may
+	// carry a collision suffix) so the comparison is independent of dedup ordering and
+	// detects only genuine subscription content changes.
 	oldMap := make(map[string]bool)
 	newMap := make(map[string]bool)
 
 	for _, cfg := range old {
-		if cfg.StableID == "" {
-			cfg.StableID = cfg.GenerateStableID()
-		}
-		oldMap[cfg.StableID] = true
+		oldMap[cfg.GenerateStableID()] = true
 	}
 
 	for _, cfg := range new {
-		if cfg.StableID == "" {
-			cfg.StableID = cfg.GenerateStableID()
-		}
-		newMap[cfg.StableID] = true
+		newMap[cfg.GenerateStableID()] = true
 	}
 
 	for id := range oldMap {


### PR DESCRIPTION
## Summary

Part **B1** of the #156 breakdown. Makes `stableID` uniquely identify each distinct proxy endpoint, fixing the collision cluster.

Closes **#149** (configs differing only by ws `path`), **#153** (Alpine `reading 'after'` crash / empty grid), **#141** (empty list on subscriptions with near-duplicate configs). Reinforces #157 (already fixed by #158).

## Problem

`GenerateStableID` hashed only `protocol/server/port/creds/sni/type/security/publicKey/fp`, so configs differing only in `path`, `host`, `shortId`, `flow`, `encryption`, `headerType`, `alpn`, ... collapsed onto one ID. Duplicate `stableId` → Alpine `x-for :key` breaks (empty/partial dashboard), and `GetProxyByStableID`/badges/Uptime Kuma can't tell colliding configs apart.

## Design (agreed with maintainer)

- **Full connection-field hash**, length-framed + keyed (unambiguous), ALPN sorted.
- **`Name`/`SubName` excluded from the hash** → renaming a server in the panel does *not* reset its ID.
- **`AssignStableIDs`** separates same-connection configs (e.g. same endpoint different name, or #141's unparsed `spx`) with a **deterministic** suffix ordered by `Name → SubName → Index` (stable across subscription reordering; first member keeps the bare hash).
- `PrepareProxyConfigs` assigns IDs over the whole set in both init and update paths.
- `IsConfigsEqual` compares the **base** hash directly (not the suffixed ID), so duplicate subscriptions don't trigger spurious reconfigurations.

## Security

`stableID` is a **public** identifier (API, badges), so low-entropy human-chosen secrets (trojan/shadowsocks `password`, hysteria `auth`) are **not** hashed into it — a truncated hash of a weak password alongside otherwise-known fields could be brute-forced (CodeQL `go/weak-sensitive-data-hashing`). The high-entropy `UUID` **is** kept: it is not brute-forceable and, with vless route-id / server-side routing, the same entry node can route different UUIDs to different exit servers, so UUID is a real destination discriminator.

## ⚠️ Breaking

`stableID`s change **once** on upgrade (different field set). Downstream monitors/badges keyed by `stableID` re-create their series once. (Same class of one-time change as #158's `fp` addition.)

## Tests

**Unit** (`models/proxy_config_test.go`): each connection field (incl. UUID) changes the ID; `Name`/`SubName`/`Index` and low-entropy secrets (`password`/`auth`) do not; ALPN order-independent; `AssignStableIDs` yields all-unique IDs and is reorder-stable.

**Live**: ran against real subscriptions — **114/114** and **22/22** proxies got unique stableIDs (incl. a sub with `@auto:443` balancer hosts). `go build` / `vet` / `gofmt -l` / `go test ./...` clean. CodeQL passes.

## Not in this PR
- B2 (Prometheus `group_name`/`stable_id` labels)
- Part C (JSON/grouped subscriptions + UI)