### PR TITLE
Round 2 / B2: add stable_id label to proxy metrics

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -78,18 +77,25 @@ func (pc *ProxyChecker) CheckProxy(proxy *models.ProxyConfig) {
 	pc.checkProxyInternal(proxy, 0, false)
 }
 
-// proxyMetricKey builds the in-memory map key for a proxy. The first four
-// "|"-separated fields (protocol, address, name, sub_name) match the Prometheus
-// label set, so ClearMetrics/ReconcileMetrics can derive the series labels from it.
-func proxyMetricKey(proxy *models.ProxyConfig) string {
-	return fmt.Sprintf("%s|%s:%d|%s|%s|%s",
-		proxy.Protocol,
-		proxy.Server,
-		proxy.Port,
-		proxy.Name,
-		proxy.SubName,
-		proxy.StableID,
-	)
+// proxyMetricLabels is the full Prometheus label set for a proxy. It doubles as the
+// in-memory map key, so series can be deleted exactly from their labels without
+// parsing a packed string (proxy names may legitimately contain any character).
+type proxyMetricLabels struct {
+	protocol string
+	address  string
+	name     string
+	subName  string
+	stableID string
+}
+
+func proxyMetricKey(proxy *models.ProxyConfig) proxyMetricLabels {
+	return proxyMetricLabels{
+		protocol: proxy.Protocol,
+		address:  fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
+		name:     proxy.Name,
+		subName:  proxy.SubName,
+		stableID: proxy.StableID,
+	}
 }
 
 func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGeneration uint64, checkGeneration bool) {
@@ -112,10 +118,11 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			return
 		}
 		metrics.RecordProxyStatus(
-			proxy.Protocol,
-			fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
-			proxy.Name,
-			proxy.SubName,
+			metricKey.protocol,
+			metricKey.address,
+			metricKey.name,
+			metricKey.subName,
+			metricKey.stableID,
 			0,
 		)
 		pc.currentMetrics.Store(metricKey, false)
@@ -126,10 +133,11 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			return
 		}
 		metrics.RecordProxyLatency(
-			proxy.Protocol,
-			fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
-			proxy.Name,
-			proxy.SubName,
+			metricKey.protocol,
+			metricKey.address,
+			metricKey.name,
+			metricKey.subName,
+			metricKey.stableID,
 			time.Duration(0),
 		)
 		pc.latencyMetrics.Store(metricKey, time.Duration(0))
@@ -188,17 +196,19 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			return
 		}
 		metrics.RecordProxyStatus(
-			proxy.Protocol,
-			fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
-			proxy.Name,
-			proxy.SubName,
+			metricKey.protocol,
+			metricKey.address,
+			metricKey.name,
+			metricKey.subName,
+			metricKey.stableID,
 			1,
 		)
 		metrics.RecordProxyLatency(
-			proxy.Protocol,
-			fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
-			proxy.Name,
-			proxy.SubName,
+			metricKey.protocol,
+			metricKey.address,
+			metricKey.name,
+			metricKey.subName,
+			metricKey.stableID,
 			latency,
 		)
 
@@ -326,12 +336,9 @@ func (pc *ProxyChecker) checkByDownload(client *http.Client) (bool, string, time
 
 func (pc *ProxyChecker) ClearMetrics() {
 	pc.currentMetrics.Range(func(key, _ interface{}) bool {
-		metricKey := key.(string)
-		parts := strings.Split(metricKey, "|")
-		if len(parts) >= 4 {
-			metrics.DeleteProxyStatus(parts[0], parts[1], parts[2], parts[3])
-			metrics.DeleteProxyLatency(parts[0], parts[1], parts[2], parts[3])
-		}
+		k := key.(proxyMetricLabels)
+		metrics.DeleteProxyStatus(k.protocol, k.address, k.name, k.subName, k.stableID)
+		metrics.DeleteProxyLatency(k.protocol, k.address, k.name, k.subName, k.stableID)
 		pc.currentMetrics.Delete(key)
 		return true
 	})
@@ -360,37 +367,26 @@ func (pc *ProxyChecker) UpdateProxies(newProxies []*models.ProxyConfig) {
 // proxies keep their freshly-refreshed values and only stale ones are pruned.
 func (pc *ProxyChecker) ReconcileMetrics() {
 	pc.mu.RLock()
-	currentKeys := make(map[string]struct{}, len(pc.proxies))
-	currentLabels := make(map[string]struct{}, len(pc.proxies))
+	currentKeys := make(map[proxyMetricLabels]struct{}, len(pc.proxies))
 	for _, proxy := range pc.proxies {
 		if proxy.StableID == "" {
 			proxy.StableID = proxy.GenerateStableID()
 		}
-		key := proxyMetricKey(proxy)
-		currentKeys[key] = struct{}{}
-		// label tuple = protocol|address|name|sub_name (first 4 key fields)
-		currentLabels[fmt.Sprintf("%s|%s:%d|%s|%s", proxy.Protocol, proxy.Server, proxy.Port, proxy.Name, proxy.SubName)] = struct{}{}
+		currentKeys[proxyMetricKey(proxy)] = struct{}{}
 	}
 	pc.mu.RUnlock()
 
-	pc.currentMetrics.Range(func(k, _ interface{}) bool {
-		metricKey := k.(string)
-		if _, ok := currentKeys[metricKey]; ok {
+	// stable_id is part of the label set, so each proxy maps to its own series; a key
+	// absent from the current set is stale and safe to delete.
+	pc.currentMetrics.Range(func(key, _ interface{}) bool {
+		k := key.(proxyMetricLabels)
+		if _, ok := currentKeys[k]; ok {
 			return true
 		}
-		parts := strings.Split(metricKey, "|")
-		if len(parts) >= 4 {
-			// Only delete the Prometheus series if no surviving proxy shares the
-			// same label tuple (guards against same-label collisions removing a
-			// still-present proxy's series).
-			labelTuple := strings.Join(parts[0:4], "|")
-			if _, used := currentLabels[labelTuple]; !used {
-				metrics.DeleteProxyStatus(parts[0], parts[1], parts[2], parts[3])
-				metrics.DeleteProxyLatency(parts[0], parts[1], parts[2], parts[3])
-			}
-		}
-		pc.currentMetrics.Delete(k)
-		pc.latencyMetrics.Delete(k)
+		metrics.DeleteProxyStatus(k.protocol, k.address, k.name, k.subName, k.stableID)
+		metrics.DeleteProxyLatency(k.protocol, k.address, k.name, k.subName, k.stableID)
+		pc.currentMetrics.Delete(key)
+		pc.latencyMetrics.Delete(key)
 		return true
 	})
 }
@@ -420,7 +416,8 @@ func (pc *ProxyChecker) CheckAllProxies() {
 
 func (pc *ProxyChecker) GetProxyStatus(name string) (bool, time.Duration, error) {
 	pc.mu.RLock()
-	var metricKey string
+	var metricKey proxyMetricLabels
+	found := false
 	for _, proxy := range pc.proxies {
 		if proxy.Name == name {
 			if proxy.StableID == "" {
@@ -428,12 +425,13 @@ func (pc *ProxyChecker) GetProxyStatus(name string) (bool, time.Duration, error)
 			}
 
 			metricKey = proxyMetricKey(proxy)
+			found = true
 			break
 		}
 	}
 	pc.mu.RUnlock()
 
-	if metricKey == "" {
+	if !found {
 		return false, 0, fmt.Errorf("proxy not found")
 	}
 

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -30,8 +30,8 @@ func mkProxy(server, name, stableID string) *models.ProxyConfig {
 // recordUp mimics what checkProxyInternal writes on a successful check.
 func recordUp(pc *ProxyChecker, p *models.ProxyConfig, lat time.Duration) {
 	addr := fmt.Sprintf("%s:%d", p.Server, p.Port)
-	metrics.RecordProxyStatus(p.Protocol, addr, p.Name, p.SubName, 1)
-	metrics.RecordProxyLatency(p.Protocol, addr, p.Name, p.SubName, lat)
+	metrics.RecordProxyStatus(p.Protocol, addr, p.Name, p.SubName, p.StableID, 1)
+	metrics.RecordProxyLatency(p.Protocol, addr, p.Name, p.SubName, p.StableID, lat)
 	pc.currentMetrics.Store(proxyMetricKey(p), true)
 	pc.latencyMetrics.Store(proxyMetricKey(p), lat)
 }
@@ -61,7 +61,7 @@ func TestUpdateProxiesKeepsMetricsAndReconcilePrunesStale(t *testing.T) {
 	if got := testutil.CollectAndCount(metrics.GetProxyStatusMetric()); got != 2 {
 		t.Fatalf("UpdateProxies must not clear metrics; expected 2 series, got %d", got)
 	}
-	if v := testutil.ToFloat64(metrics.GetProxyStatusMetric().WithLabelValues("vless", "1.1.1.1:443", "A", "sub")); v != 1 {
+	if v := testutil.ToFloat64(metrics.GetProxyStatusMetric().WithLabelValues("vless", "1.1.1.1:443", "A", "sub", "ida")); v != 1 {
 		t.Fatalf("surviving proxy A must keep status 1 across the update, got %v", v)
 	}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -33,7 +33,7 @@ func InitMetrics(instance string) {
 	metricsInstance = instance
 	hasInstance = instance != ""
 
-	labels := []string{"protocol", "address", "name", "sub_name"}
+	labels := []string{"protocol", "address", "name", "sub_name", "stable_id"}
 	if hasInstance {
 		labels = append(labels, "instance")
 	}
@@ -63,28 +63,28 @@ func GetProxyLatencyMetric() *prometheus.GaugeVec {
 	return proxyLatency
 }
 
-func buildLabelValues(protocol, address, name, subName string) []string {
-	labels := []string{protocol, address, name, subName}
+func buildLabelValues(protocol, address, name, subName, stableID string) []string {
+	labels := []string{protocol, address, name, subName, stableID}
 	if hasInstance {
 		labels = append(labels, metricsInstance)
 	}
 	return labels
 }
 
-func RecordProxyStatus(protocol, address, name, subName string, value float64) {
-	proxyStatus.WithLabelValues(buildLabelValues(protocol, address, name, subName)...).Set(value)
+func RecordProxyStatus(protocol, address, name, subName, stableID string, value float64) {
+	proxyStatus.WithLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...).Set(value)
 }
 
-func RecordProxyLatency(protocol, address, name, subName string, value time.Duration) {
-	proxyLatency.WithLabelValues(buildLabelValues(protocol, address, name, subName)...).Set(float64(value.Milliseconds()))
+func RecordProxyLatency(protocol, address, name, subName, stableID string, value time.Duration) {
+	proxyLatency.WithLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...).Set(float64(value.Milliseconds()))
 }
 
-func DeleteProxyStatus(protocol, address, name, subName string) {
-	proxyStatus.DeleteLabelValues(buildLabelValues(protocol, address, name, subName)...)
+func DeleteProxyStatus(protocol, address, name, subName, stableID string) {
+	proxyStatus.DeleteLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...)
 }
 
-func DeleteProxyLatency(protocol, address, name, subName string) {
-	proxyLatency.DeleteLabelValues(buildLabelValues(protocol, address, name, subName)...)
+func DeleteProxyLatency(protocol, address, name, subName, stableID string) {
+	proxyLatency.DeleteLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...)
 }
 
 func ParseURL(remoteWriteURL string) (*RemoteWriteConfig, error) {


### PR DESCRIPTION
## Summary

Part **B2** of the #156 breakdown. Adds `stable_id` to the `xray_proxy_status` / `xray_proxy_latency_ms` label set so each proxy gets its own Prometheus series.

## Problem

The label set was `[protocol, address, name, sub_name]`. Two proxies sharing those four values collapsed into a single series (last-write-wins) — e.g. same `server:port` and display name but a different transport, or vless route-id configs that differ only by UUID. B1 (#163) made `stableID` unique per endpoint; this PR exposes it as a label so the metrics layer stops colliding too.

## Changes

- `metrics`: add `stable_id` to both gauges' label set and to all record/delete helpers.
- `checker`: replace the packed `"|"`-joined in-memory metric key with a comparable `proxyMetricLabels` struct used directly as the `sync.Map` key. Series are now deleted from their exact label values instead of splitting a string — which was fragile for proxy names containing `|` (e.g. the upcoming grouped `Group | node` naming). `ClearMetrics` / `ReconcileMetrics` / `GetProxyStatus` updated to match.

## ⚠️ Breaking

`xray_proxy_*` series gain a `stable_id` label, which changes series identity. Grafana dashboards / alerts that pin or aggregate on the old label set need updating. `group_name` will be added later with the grouped-subscription feature (Part C), so the metric labels see one more change then.

## Tests

Unit (`checker`): `UpdateProxies` keeps existing series, surviving proxies keep status across an update, `ReconcileMetrics` prunes only removed proxies — now exercised through the struct key + `stable_id`.

Live: a real 114-proxy subscription yields **114 series with 114 unique `stable_id`** labels (no collisions). `go build` / `vet` / `gofmt -l` / `go test ./...` clean. Based on merged B1 (#163).

## Next
- Part C (JSON/grouped subscriptions + grouped UI; adds `group_name`).