### PR TITLE
feat: JSON/balancer subscriptions, grouped dashboard, xhttp & config robustness

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -81,20 +81,22 @@ func (pc *ProxyChecker) CheckProxy(proxy *models.ProxyConfig) {
 // in-memory map key, so series can be deleted exactly from their labels without
 // parsing a packed string (proxy names may legitimately contain any character).
 type proxyMetricLabels struct {
-	protocol string
-	address  string
-	name     string
-	subName  string
-	stableID string
+	protocol  string
+	address   string
+	name      string
+	subName   string
+	stableID  string
+	groupName string
 }
 
 func proxyMetricKey(proxy *models.ProxyConfig) proxyMetricLabels {
 	return proxyMetricLabels{
-		protocol: proxy.Protocol,
-		address:  fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
-		name:     proxy.Name,
-		subName:  proxy.SubName,
-		stableID: proxy.StableID,
+		protocol:  proxy.Protocol,
+		address:   fmt.Sprintf("%s:%d", proxy.Server, proxy.Port),
+		name:      proxy.Name,
+		subName:   proxy.SubName,
+		stableID:  proxy.StableID,
+		groupName: proxy.GroupName,
 	}
 }
 
@@ -122,7 +124,7 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			metricKey.address,
 			metricKey.name,
 			metricKey.subName,
-			metricKey.stableID,
+			metricKey.stableID, metricKey.groupName,
 			0,
 		)
 		pc.currentMetrics.Store(metricKey, false)
@@ -137,7 +139,7 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			metricKey.address,
 			metricKey.name,
 			metricKey.subName,
-			metricKey.stableID,
+			metricKey.stableID, metricKey.groupName,
 			time.Duration(0),
 		)
 		pc.latencyMetrics.Store(metricKey, time.Duration(0))
@@ -200,7 +202,7 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			metricKey.address,
 			metricKey.name,
 			metricKey.subName,
-			metricKey.stableID,
+			metricKey.stableID, metricKey.groupName,
 			1,
 		)
 		metrics.RecordProxyLatency(
@@ -208,7 +210,7 @@ func (pc *ProxyChecker) checkProxyInternal(proxy *models.ProxyConfig, expectedGe
 			metricKey.address,
 			metricKey.name,
 			metricKey.subName,
-			metricKey.stableID,
+			metricKey.stableID, metricKey.groupName,
 			latency,
 		)
 
@@ -337,8 +339,8 @@ func (pc *ProxyChecker) checkByDownload(client *http.Client) (bool, string, time
 func (pc *ProxyChecker) ClearMetrics() {
 	pc.currentMetrics.Range(func(key, _ interface{}) bool {
 		k := key.(proxyMetricLabels)
-		metrics.DeleteProxyStatus(k.protocol, k.address, k.name, k.subName, k.stableID)
-		metrics.DeleteProxyLatency(k.protocol, k.address, k.name, k.subName, k.stableID)
+		metrics.DeleteProxyStatus(k.protocol, k.address, k.name, k.subName, k.stableID, k.groupName)
+		metrics.DeleteProxyLatency(k.protocol, k.address, k.name, k.subName, k.stableID, k.groupName)
 		pc.currentMetrics.Delete(key)
 		return true
 	})
@@ -383,8 +385,8 @@ func (pc *ProxyChecker) ReconcileMetrics() {
 		if _, ok := currentKeys[k]; ok {
 			return true
 		}
-		metrics.DeleteProxyStatus(k.protocol, k.address, k.name, k.subName, k.stableID)
-		metrics.DeleteProxyLatency(k.protocol, k.address, k.name, k.subName, k.stableID)
+		metrics.DeleteProxyStatus(k.protocol, k.address, k.name, k.subName, k.stableID, k.groupName)
+		metrics.DeleteProxyLatency(k.protocol, k.address, k.name, k.subName, k.stableID, k.groupName)
 		pc.currentMetrics.Delete(key)
 		pc.latencyMetrics.Delete(key)
 		return true

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -30,8 +30,8 @@ func mkProxy(server, name, stableID string) *models.ProxyConfig {
 // recordUp mimics what checkProxyInternal writes on a successful check.
 func recordUp(pc *ProxyChecker, p *models.ProxyConfig, lat time.Duration) {
 	addr := fmt.Sprintf("%s:%d", p.Server, p.Port)
-	metrics.RecordProxyStatus(p.Protocol, addr, p.Name, p.SubName, p.StableID, 1)
-	metrics.RecordProxyLatency(p.Protocol, addr, p.Name, p.SubName, p.StableID, lat)
+	metrics.RecordProxyStatus(p.Protocol, addr, p.Name, p.SubName, p.StableID, p.GroupName, 1)
+	metrics.RecordProxyLatency(p.Protocol, addr, p.Name, p.SubName, p.StableID, p.GroupName, lat)
 	pc.currentMetrics.Store(proxyMetricKey(p), true)
 	pc.latencyMetrics.Store(proxyMetricKey(p), lat)
 }
@@ -61,7 +61,7 @@ func TestUpdateProxiesKeepsMetricsAndReconcilePrunesStale(t *testing.T) {
 	if got := testutil.CollectAndCount(metrics.GetProxyStatusMetric()); got != 2 {
 		t.Fatalf("UpdateProxies must not clear metrics; expected 2 series, got %d", got)
 	}
-	if v := testutil.ToFloat64(metrics.GetProxyStatusMetric().WithLabelValues("vless", "1.1.1.1:443", "A", "sub", "ida")); v != 1 {
+	if v := testutil.ToFloat64(metrics.GetProxyStatusMetric().WithLabelValues("vless", "1.1.1.1:443", "A", "sub", "ida", "")); v != 1 {
 		t.Fatalf("surviving proxy A must keep status 1 across the update, got %v", v)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ type CLI struct {
 		URLs           []string `name:"subscription-url" help:"URL(s) of the subscription (can be specified multiple times)" required:"true" env:"SUBSCRIPTION_URL"`
 		Update         bool     `name:"subscription-update" help:"Whether to recheck the subscription" default:"true" env:"SUBSCRIPTION_UPDATE"`
 		UpdateInterval int      `name:"subscription-update-interval" help:"Interval for subscription updates in seconds" default:"300" env:"SUBSCRIPTION_UPDATE_INTERVAL"`
+		JSONFormat     bool     `name:"subscription-json-format" help:"Request full JSON configs from the panel (sends app-like headers so grouped/balancer nodes are returned individually instead of collapsed share links)" default:"false" env:"SUBSCRIPTION_JSON_FORMAT"`
+		UserAgent      string   `name:"subscription-user-agent" help:"Custom User-Agent for subscription requests (overrides the default and the --subscription-json-format preset)" default:"" env:"SUBSCRIPTION_USER_AGENT"`
+		Headers        []string `name:"subscription-header" help:"Extra HTTP header for subscription requests in 'Key: Value' form (repeatable; env: comma-separated)" env:"SUBSCRIPTION_HEADERS"`
 	} `embed:"" prefix:""`
 
 	Proxy struct {
@@ -58,9 +61,10 @@ type CLI struct {
 	} `embed:"" prefix:""`
 
 	Web struct {
-		ShowServerDetails bool   `name:"web-show-details" help:"Show server IP addresses and ports in web UI" default:"false" env:"WEB_SHOW_DETAILS"`
-		Public            bool   `name:"web-public" help:"Make dashboard public (requires --metrics-protected)" default:"false" env:"WEB_PUBLIC"`
-		CustomAssetsPath  string `name:"web-custom-assets-path" help:"Path to custom assets directory (logo.svg, favicon.ico, custom.css, index.html)" default:"" env:"WEB_CUSTOM_ASSETS_PATH"`
+		ShowServerDetails   bool   `name:"web-show-details" help:"Show server IP addresses and ports in web UI" default:"false" env:"WEB_SHOW_DETAILS"`
+		Public              bool   `name:"web-public" help:"Make dashboard public (requires --metrics-protected)" default:"false" env:"WEB_PUBLIC"`
+		TrustedExternalAuth bool   `name:"web-trusted-external-auth" help:"Allow server details in public mode when an external auth proxy protects the dashboard" default:"false" env:"WEB_TRUSTED_EXTERNAL_AUTH"`
+		CustomAssetsPath    string `name:"web-custom-assets-path" help:"Path to custom assets directory (logo.svg, favicon.ico, custom.css, index.html)" default:"" env:"WEB_CUSTOM_ASSETS_PATH"`
 	} `embed:"" prefix:""`
 
 	Version  VersionFlag `name:"version" help:"Print version information and quit"`

--- a/main.go
+++ b/main.go
@@ -229,14 +229,16 @@ func updateConfiguration(newConfigs []*models.ProxyConfig, currentConfigs *[]*mo
 
 	configFile := "xray_config.json"
 	configGenerator := xray.NewConfigGenerator()
-	if err := configGenerator.GenerateAndSaveConfig(
+	validProxies, err := configGenerator.GenerateValidatedConfig(
 		newConfigs,
 		config.CLIConfig.Xray.StartPort,
 		configFile,
 		config.CLIConfig.Xray.LogLevel,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
+	newConfigs = validProxies
 
 	if err := xrayRunner.Stop(); err != nil {
 		return err

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -33,7 +33,7 @@ func InitMetrics(instance string) {
 	metricsInstance = instance
 	hasInstance = instance != ""
 
-	labels := []string{"protocol", "address", "name", "sub_name", "stable_id"}
+	labels := []string{"protocol", "address", "name", "sub_name", "stable_id", "group_name"}
 	if hasInstance {
 		labels = append(labels, "instance")
 	}
@@ -63,28 +63,28 @@ func GetProxyLatencyMetric() *prometheus.GaugeVec {
 	return proxyLatency
 }
 
-func buildLabelValues(protocol, address, name, subName, stableID string) []string {
-	labels := []string{protocol, address, name, subName, stableID}
+func buildLabelValues(protocol, address, name, subName, stableID, groupName string) []string {
+	labels := []string{protocol, address, name, subName, stableID, groupName}
 	if hasInstance {
 		labels = append(labels, metricsInstance)
 	}
 	return labels
 }
 
-func RecordProxyStatus(protocol, address, name, subName, stableID string, value float64) {
-	proxyStatus.WithLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...).Set(value)
+func RecordProxyStatus(protocol, address, name, subName, stableID, groupName string, value float64) {
+	proxyStatus.WithLabelValues(buildLabelValues(protocol, address, name, subName, stableID, groupName)...).Set(value)
 }
 
-func RecordProxyLatency(protocol, address, name, subName, stableID string, value time.Duration) {
-	proxyLatency.WithLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...).Set(float64(value.Milliseconds()))
+func RecordProxyLatency(protocol, address, name, subName, stableID, groupName string, value time.Duration) {
+	proxyLatency.WithLabelValues(buildLabelValues(protocol, address, name, subName, stableID, groupName)...).Set(float64(value.Milliseconds()))
 }
 
-func DeleteProxyStatus(protocol, address, name, subName, stableID string) {
-	proxyStatus.DeleteLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...)
+func DeleteProxyStatus(protocol, address, name, subName, stableID, groupName string) {
+	proxyStatus.DeleteLabelValues(buildLabelValues(protocol, address, name, subName, stableID, groupName)...)
 }
 
-func DeleteProxyLatency(protocol, address, name, subName, stableID string) {
-	proxyLatency.DeleteLabelValues(buildLabelValues(protocol, address, name, subName, stableID)...)
+func DeleteProxyLatency(protocol, address, name, subName, stableID, groupName string) {
+	proxyLatency.DeleteLabelValues(buildLabelValues(protocol, address, name, subName, stableID, groupName)...)
 }
 
 func ParseURL(remoteWriteURL string) (*RemoteWriteConfig, error) {

--- a/models/proxy_config.go
+++ b/models/proxy_config.go
@@ -42,7 +42,9 @@ type ProxyConfig struct {
 	Settings         map[string]string
 	StableID         string
 	RawXhttpSettings string
+	RawKcpSettings   string
 	SubName          string
+	GroupName        string
 
 	// Hysteria2 fields
 	HysteriaAuth         string
@@ -146,6 +148,7 @@ func (pc *ProxyConfig) GenerateStableID() string {
 	write("serviceName", pc.ServiceName)
 	write("mode", pc.Mode)
 	write("rawXhttp", pc.RawXhttpSettings)
+	write("rawKcp", pc.RawKcpSettings)
 
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }

--- a/subscription/parser.go
+++ b/subscription/parser.go
@@ -19,6 +19,16 @@ import (
 	libXray "github.com/xtls/libxray"
 )
 
+const (
+	// subscriptionHWID is a fixed device id sent with subscription requests. It is
+	// intentionally constant (not per-request) so panels that enforce HWID/device
+	// limits register a single device for the checker.
+	subscriptionHWID = "0JLQq9Ca0JvQrtCn0Jgg0JHQm9Cp0KLQrCBIV0lE"
+	// subscriptionJSONUserAgent impersonates an app whose responses are full JSON
+	// configs (used when --subscription-json-format is enabled).
+	subscriptionJSONUserAgent = "Happ/1.0"
+)
+
 type Parser struct{}
 
 type fetchResult struct {
@@ -70,6 +80,7 @@ type libXrayStreamSettings struct {
 	HttpupgradeSettings *libXrayHttpupgradeSettings `json:"httpupgradeSettings"`
 	XhttpSettings       json.RawMessage             `json:"xhttpSettings"`
 	SplithttpSettings   json.RawMessage             `json:"splithttpSettings"`
+	KcpSettings         json.RawMessage             `json:"kcpSettings"`
 	HysteriaSettings    *libXrayHysteriaSettings    `json:"hysteriaSettings"`
 	Sockopt             *libXraySockopt             `json:"sockopt"`
 	FinalMask           *libXrayFinalMask           `json:"finalMask"`
@@ -400,6 +411,47 @@ func (p *Parser) extractOutbounds(data json.RawMessage, originalData map[string]
 	return proxyConfigs
 }
 
+// nameGroupedProxies assigns display names to the proxies parsed from a single JSON
+// config (one `remarks` group). A single-node group takes the group name; a
+// multi-node group (a balancer) names each node "<group> | <node>" so the nodes are
+// tracked individually. Each proxy's Name is expected to already hold its outbound
+// tag (set by convertOutbound); server:port is used as a fallback and to
+// disambiguate nodes that share a tag.
+func nameGroupedProxies(remarks string, group []*models.ProxyConfig) {
+	if len(group) == 0 {
+		return
+	}
+	if len(group) == 1 {
+		if remarks != "" {
+			group[0].Name = remarks
+		}
+		return
+	}
+
+	nodeLabel := func(pc *models.ProxyConfig) string {
+		if pc.Name != "" {
+			return pc.Name
+		}
+		return fmt.Sprintf("%s:%d", pc.Server, pc.Port)
+	}
+	labelCounts := make(map[string]int, len(group))
+	for _, pc := range group {
+		labelCounts[nodeLabel(pc)]++
+	}
+	for _, pc := range group {
+		node := nodeLabel(pc)
+		if labelCounts[node] > 1 {
+			node = fmt.Sprintf("%s (%s:%d)", node, pc.Server, pc.Port)
+		}
+		if remarks != "" {
+			pc.Name = fmt.Sprintf("%s | %s", remarks, node)
+			pc.GroupName = remarks
+		} else {
+			pc.Name = node
+		}
+	}
+}
+
 func (p *Parser) parseJSONConfigs(data []byte) ([]*models.ProxyConfig, error) {
 	var configs []struct {
 		Remarks   string            `json:"remarks"`
@@ -416,19 +468,17 @@ func (p *Parser) parseJSONConfigs(data []byte) ([]*models.ProxyConfig, error) {
 	configIndex := 0
 
 	for _, config := range configs {
+		var group []*models.ProxyConfig
 		for _, outboundRaw := range config.Outbounds {
 			proxyConfig, err := p.convertOutbound(outboundRaw, configIndex, nil)
-			if err != nil {
+			if err != nil || proxyConfig == nil {
 				continue
 			}
-			if proxyConfig != nil {
-				if config.Remarks != "" {
-					proxyConfig.Name = config.Remarks
-				}
-				proxyConfigs = append(proxyConfigs, proxyConfig)
-				configIndex++
-			}
+			group = append(group, proxyConfig)
+			configIndex++
 		}
+		nameGroupedProxies(config.Remarks, group)
+		proxyConfigs = append(proxyConfigs, group...)
 	}
 
 	if len(proxyConfigs) == 0 {
@@ -455,17 +505,14 @@ func (p *Parser) parseSingleJSONConfig(data []byte) ([]*models.ProxyConfig, erro
 
 	for _, outboundRaw := range config.Outbounds {
 		proxyConfig, err := p.convertOutbound(outboundRaw, configIndex, nil)
-		if err != nil {
+		if err != nil || proxyConfig == nil {
 			continue
 		}
-		if proxyConfig != nil {
-			if config.Remarks != "" {
-				proxyConfig.Name = config.Remarks
-			}
-			proxyConfigs = append(proxyConfigs, proxyConfig)
-			configIndex++
-		}
+		proxyConfigs = append(proxyConfigs, proxyConfig)
+		configIndex++
 	}
+
+	nameGroupedProxies(config.Remarks, proxyConfigs)
 
 	if len(proxyConfigs) == 0 {
 		return nil, fmt.Errorf("no valid proxy configurations found in single JSON config")
@@ -512,12 +559,35 @@ func (p *Parser) fetchURLContent(source string) (*fetchResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "Xray-Checker")
+
+	sub := config.CLIConfig.Subscription
 	req.Header.Set("Accept", "*/*")
-	req.Header.Set("X-Device-OS", "CheckerOS")
-	req.Header.Set("X-Ver-OS", config.Version)
-	req.Header.Set("X-Device-Model", "Xray-Checker Pro Max")
-	req.Header.Set("X-Hwid", "0JLQq9Ca0JvQrtCn0Jgg0JHQm9Cp0KLQrCBIV0lE")
+	switch {
+	case sub.UserAgent != "":
+		// Explicit override: the user controls exactly which client to impersonate.
+		req.Header.Set("User-Agent", sub.UserAgent)
+	case sub.JSONFormat:
+		// App-like headers so panels (e.g. Remnawave) return full JSON configs with
+		// individual grouped/balancer nodes instead of collapsed base64 share links.
+		req.Header.Set("User-Agent", subscriptionJSONUserAgent)
+		req.Header.Set("X-Hwid", subscriptionHWID)
+	default:
+		req.Header.Set("User-Agent", "Xray-Checker")
+		req.Header.Set("X-Device-OS", "CheckerOS")
+		req.Header.Set("X-Ver-OS", config.Version)
+		req.Header.Set("X-Device-Model", "Xray-Checker Pro Max")
+		req.Header.Set("X-Hwid", subscriptionHWID)
+	}
+
+	// User-supplied headers are applied last so they can override any of the above.
+	for _, h := range sub.Headers {
+		key, value, ok := strings.Cut(h, ":")
+		if !ok {
+			logger.Warn("Ignoring malformed subscription header (want 'Key: Value'): %s", h)
+			continue
+		}
+		req.Header.Set(strings.TrimSpace(key), strings.TrimSpace(value))
+	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
@@ -875,6 +945,10 @@ func (p *Parser) convertOutbound(raw json.RawMessage, index int, originalData ma
 			pc.Host = ss.HttpupgradeSettings.Host
 		}
 
+		if (ss.Network == "kcp" || ss.Network == "mkcp") && len(ss.KcpSettings) > 0 {
+			pc.RawKcpSettings = string(ss.KcpSettings)
+		}
+
 		if ss.Network == "xhttp" || ss.Network == "splithttp" {
 			pc.Type = ss.Network
 
@@ -1063,16 +1137,13 @@ func (p *Parser) parseSingleConfigFile(data []byte, startIndex int) ([]*models.P
 		var proxyConfigs []*models.ProxyConfig
 		for _, outboundRaw := range config.Outbounds {
 			proxyConfig, err := p.convertOutbound(outboundRaw, startIndex, nil)
-			if err != nil {
+			if err != nil || proxyConfig == nil {
 				continue
 			}
-			if proxyConfig != nil {
-				if config.Remarks != "" {
-					proxyConfig.Name = config.Remarks
-				}
-				proxyConfigs = append(proxyConfigs, proxyConfig)
-			}
+			proxyConfigs = append(proxyConfigs, proxyConfig)
 		}
+
+		nameGroupedProxies(config.Remarks, proxyConfigs)
 
 		if len(proxyConfigs) == 0 {
 			return nil, fmt.Errorf("no valid proxy configurations found")

--- a/subscription/parser_test.go
+++ b/subscription/parser_test.go
@@ -1,0 +1,72 @@
+package subscription
+
+import (
+	"testing"
+
+	"xray-checker/models"
+)
+
+func node(name, server string, port int) *models.ProxyConfig {
+	return &models.ProxyConfig{Name: name, Server: server, Port: port, Protocol: "vless"}
+}
+
+func TestNameGroupedProxies_SingleNodeTakesRemarks(t *testing.T) {
+	g := []*models.ProxyConfig{node("original-tag", "s1", 443)}
+	nameGroupedProxies("🇳🇱 Netherlands", g)
+	if g[0].Name != "🇳🇱 Netherlands" {
+		t.Errorf("single node should take the group remarks, got %q", g[0].Name)
+	}
+}
+
+func TestNameGroupedProxies_SingleNodeKeepsTagWhenNoRemarks(t *testing.T) {
+	g := []*models.ProxyConfig{node("original-tag", "s1", 443)}
+	nameGroupedProxies("", g)
+	if g[0].Name != "original-tag" {
+		t.Errorf("single node with no remarks should keep its tag, got %q", g[0].Name)
+	}
+}
+
+func TestNameGroupedProxies_MultiNodeCombinesRemarksAndTag(t *testing.T) {
+	g := []*models.ProxyConfig{
+		node("NL", "nl.example.com", 443),
+		node("DE", "de.example.com", 443),
+	}
+	nameGroupedProxies("Auto", g)
+	want := map[string]bool{"Auto | NL": true, "Auto | DE": true}
+	for _, pc := range g {
+		if !want[pc.Name] {
+			t.Errorf("unexpected node name %q", pc.Name)
+		}
+	}
+}
+
+func TestNameGroupedProxies_DisambiguatesDuplicateTags(t *testing.T) {
+	g := []*models.ProxyConfig{
+		node("NL", "nl-1.example.com", 443),
+		node("NL", "nl-2.example.com", 443),
+	}
+	nameGroupedProxies("Auto", g)
+	if g[0].Name == g[1].Name {
+		t.Fatalf("nodes with duplicate tags must get distinct names, both %q", g[0].Name)
+	}
+	for _, pc := range g {
+		// duplicated tag -> server:port appended for disambiguation
+		if pc.Name != "Auto | NL (nl-1.example.com:443)" && pc.Name != "Auto | NL (nl-2.example.com:443)" {
+			t.Errorf("expected disambiguated name, got %q", pc.Name)
+		}
+	}
+}
+
+func TestNameGroupedProxies_MultiNodeFallsBackToServerWhenNoTag(t *testing.T) {
+	g := []*models.ProxyConfig{
+		node("", "a.example.com", 443),
+		node("", "b.example.com", 443),
+	}
+	nameGroupedProxies("Auto", g)
+	want := map[string]bool{"Auto | a.example.com:443": true, "Auto | b.example.com:443": true}
+	for _, pc := range g {
+		if !want[pc.Name] {
+			t.Errorf("expected server-based node name, got %q", pc.Name)
+		}
+	}
+}

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -53,14 +53,16 @@ func InitializeConfiguration(configFile string, version string) (*[]*models.Prox
 	xray.PrepareProxyConfigs(proxyConfigs)
 
 	configGenerator := xray.NewConfigGenerator()
-	if err := configGenerator.GenerateAndSaveConfig(
+	validProxies, err := configGenerator.GenerateValidatedConfig(
 		proxyConfigs,
 		config.CLIConfig.Xray.StartPort,
 		configFile,
 		config.CLIConfig.Xray.LogLevel,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, err
 	}
+	proxyConfigs = validProxies
 
 	return &proxyConfigs, nil
 }

--- a/web/api.go
+++ b/web/api.go
@@ -10,22 +10,24 @@ import (
 	"xray-checker/checker"
 	"xray-checker/config"
 	"xray-checker/models"
+	"xray-checker/xray"
 )
 
 //go:embed openapi.yaml
 var openAPISpec []byte
 
 type ProxyInfo struct {
-	Index     int    `json:"index"`
-	StableID  string `json:"stableId"`
-	Name      string `json:"name"`
-	SubName   string `json:"subName"`
-	Server    string `json:"server"`
-	Port      int    `json:"port"`
-	Protocol  string `json:"protocol"`
-	ProxyPort int    `json:"proxyPort"`
-	Online    bool   `json:"online"`
-	LatencyMs int64  `json:"latencyMs"`
+	Index           int                    `json:"index"`
+	StableID        string                 `json:"stableId"`
+	Name            string                 `json:"name"`
+	SubName         string                 `json:"subName"`
+	Server          string                 `json:"server"`
+	Port            int                    `json:"port"`
+	Protocol        string                 `json:"protocol"`
+	ProxyPort       int                    `json:"proxyPort"`
+	Online          bool                   `json:"online"`
+	LatencyMs       int64                  `json:"latencyMs"`
+	GeneratedConfig map[string]interface{} `json:"generatedConfig,omitempty"`
 }
 
 type PublicProxyInfo struct {
@@ -87,8 +89,8 @@ func writeError(w http.ResponseWriter, message string, code int) {
 	})
 }
 
-func toProxyInfo(proxy *models.ProxyConfig, online bool, latency time.Duration, startPort int) ProxyInfo {
-	return ProxyInfo{
+func toProxyInfo(proxy *models.ProxyConfig, online bool, latency time.Duration, startPort int, includeDetails bool) ProxyInfo {
+	info := ProxyInfo{
 		Index:     proxy.Index,
 		StableID:  proxy.StableID,
 		Name:      proxy.Name,
@@ -100,6 +102,91 @@ func toProxyInfo(proxy *models.ProxyConfig, online bool, latency time.Duration, 
 		Online:    online,
 		LatencyMs: latency.Milliseconds(),
 	}
+	if includeDetails {
+		outbound := xray.NewConfigGenerator().GenerateProxyOutbound(proxy)
+		info.GeneratedConfig = sanitizeGeneratedConfig(outbound)
+	}
+	return info
+}
+
+// shouldShowServerDetails reports whether sensitive proxy details (server
+// address/port on the dashboard, generated config in the API) may be exposed.
+// Details are off unless WEB_SHOW_DETAILS is set, and additionally suppressed in
+// public mode unless the operator declares the dashboard is protected by an
+// external auth proxy via WEB_TRUSTED_EXTERNAL_AUTH.
+func shouldShowServerDetails() bool {
+	if !config.CLIConfig.Web.ShowServerDetails {
+		return false
+	}
+	if config.CLIConfig.Web.Public && !config.CLIConfig.Web.TrustedExternalAuth {
+		return false
+	}
+	return true
+}
+
+// sanitizeGeneratedConfig returns a copy of the generated outbound config with
+// secret values masked, safe to expose for inspection.
+func sanitizeGeneratedConfig(value interface{}) map[string]interface{} {
+	sanitized, ok := sanitizeGeneratedValue(value).(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return sanitized
+}
+
+// sanitizeGeneratedValue recursively walks a generated config value and masks
+// the middle of any secret field. Only low-entropy/credential keys are masked;
+// public material such as reality publicKey/shortId is left intact so the config
+// stays useful for debugging.
+func sanitizeGeneratedValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(typed))
+		for key, nested := range typed {
+			switch strings.ToLower(key) {
+			case "id", "password", "auth", "seed":
+				if text, ok := nested.(string); ok {
+					result[key] = maskMiddle(text)
+					continue
+				}
+			}
+			result[key] = sanitizeGeneratedValue(nested)
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(typed))
+		for i, nested := range typed {
+			result[i] = sanitizeGeneratedValue(nested)
+		}
+		return result
+	case []map[string]interface{}:
+		result := make([]interface{}, len(typed))
+		for i, nested := range typed {
+			result[i] = sanitizeGeneratedValue(nested)
+		}
+		return result
+	case []string:
+		result := make([]interface{}, len(typed))
+		for i, nested := range typed {
+			result[i] = nested
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+// maskMiddle hides the middle of a secret, keeping a short prefix/suffix so the
+// value stays recognizable. Short values are fully masked to avoid leaking
+// low-entropy secrets.
+func maskMiddle(value string) string {
+	if value == "" {
+		return ""
+	}
+	if len(value) <= 8 {
+		return "****"
+	}
+	return value[:4] + "..." + value[len(value)-4:]
 }
 
 // APIPublicProxiesHandler returns public info for all proxies (no auth required)
@@ -139,10 +226,11 @@ func APIProxiesHandler(proxyChecker *checker.ProxyChecker, startPort int) http.H
 	return func(w http.ResponseWriter, r *http.Request) {
 		proxies := proxyChecker.GetProxies()
 		result := make([]ProxyInfo, 0, len(proxies))
+		includeDetails := shouldShowServerDetails()
 
 		for _, proxy := range proxies {
 			status, latency, _ := proxyChecker.GetProxyStatus(proxy.Name)
-			result = append(result, toProxyInfo(proxy, status, latency, startPort))
+			result = append(result, toProxyInfo(proxy, status, latency, startPort, includeDetails))
 		}
 
 		writeJSON(w, result)
@@ -180,7 +268,7 @@ func APIProxyHandler(proxyChecker *checker.ProxyChecker, startPort int) http.Han
 		}
 
 		status, latency, _ := proxyChecker.GetProxyStatus(proxy.Name)
-		writeJSON(w, toProxyInfo(proxy, status, latency, startPort))
+		writeJSON(w, toProxyInfo(proxy, status, latency, startPort, shouldShowServerDetails()))
 	}
 }
 

--- a/web/api_test.go
+++ b/web/api_test.go
@@ -1,0 +1,108 @@
+package web
+
+import (
+	"testing"
+
+	"xray-checker/config"
+)
+
+func TestMaskMiddle(t *testing.T) {
+	cases := map[string]string{
+		"":                                     "",
+		"short":                                "****", // <= 8 chars fully masked
+		"12345678":                             "****", // exactly 8 still fully masked
+		"123456789":                            "1234...6789",
+		"d342d11e-d424-4583-b36e-524ab1f0afa4": "d342...afa4",
+	}
+	for in, want := range cases {
+		if got := maskMiddle(in); got != want {
+			t.Errorf("maskMiddle(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizeGeneratedConfigMasksSecretsKeepsPublic(t *testing.T) {
+	// Mirrors the shape of a generated vless+reality+hysteria outbound.
+	outbound := map[string]interface{}{
+		"tag":      "node_0",
+		"protocol": "vless",
+		"settings": map[string]interface{}{
+			"vnext": []map[string]interface{}{
+				{
+					"address": "example.com",
+					"port":    443,
+					"users": []map[string]interface{}{
+						{"id": "d342d11e-d424-4583-b36e-524ab1f0afa4", "encryption": "none"},
+					},
+				},
+			},
+		},
+		"streamSettings": map[string]interface{}{
+			"realitySettings": map[string]interface{}{
+				"publicKey": "Vft7...PuBLiCkeYmaterialShouldStay",
+				"shortId":   "0123abcd",
+			},
+			"hysteriaSettings": map[string]interface{}{
+				"auth": "super-secret-hysteria-auth-token",
+			},
+			"kcpSettings": map[string]interface{}{
+				"seed": "my-kcp-seed-value",
+			},
+		},
+	}
+
+	got := sanitizeGeneratedConfig(outbound)
+	if got == nil {
+		t.Fatal("sanitizeGeneratedConfig returned nil")
+	}
+
+	user := got["settings"].(map[string]interface{})["vnext"].([]interface{})[0].(map[string]interface{})["users"].([]interface{})[0].(map[string]interface{})
+	if user["id"] != "d342...afa4" {
+		t.Errorf("uuid not masked: %v", user["id"])
+	}
+
+	stream := got["streamSettings"].(map[string]interface{})
+	if stream["realitySettings"].(map[string]interface{})["publicKey"] == "****" {
+		t.Error("publicKey must NOT be masked (it is public material)")
+	}
+	if stream["hysteriaSettings"].(map[string]interface{})["auth"] != "supe...oken" {
+		t.Errorf("hysteria auth not masked: %v", stream["hysteriaSettings"].(map[string]interface{})["auth"])
+	}
+	if stream["kcpSettings"].(map[string]interface{})["seed"] != "my-k...alue" {
+		t.Errorf("kcp seed not masked: %v", stream["kcpSettings"].(map[string]interface{})["seed"])
+	}
+	// Non-secret fields are preserved untouched.
+	if got["tag"] != "node_0" || got["protocol"] != "vless" {
+		t.Errorf("non-secret fields altered: tag=%v protocol=%v", got["tag"], got["protocol"])
+	}
+}
+
+func TestShouldShowServerDetails(t *testing.T) {
+	cases := []struct {
+		name    string
+		show    bool
+		public  bool
+		trusted bool
+		want    bool
+	}{
+		{"off by default", false, false, false, false},
+		{"on, private", true, false, false, true},
+		{"on, public, untrusted -> hidden", true, true, false, false},
+		{"on, public, trusted -> shown", true, true, true, true},
+		{"off, public, trusted -> still off", false, true, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			config.CLIConfig.Web.ShowServerDetails = c.show
+			config.CLIConfig.Web.Public = c.public
+			config.CLIConfig.Web.TrustedExternalAuth = c.trusted
+			if got := shouldShowServerDetails(); got != c.want {
+				t.Errorf("shouldShowServerDetails() = %v, want %v", got, c.want)
+			}
+		})
+	}
+	// reset
+	config.CLIConfig.Web.ShowServerDetails = false
+	config.CLIConfig.Web.Public = false
+	config.CLIConfig.Web.TrustedExternalAuth = false
+}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -27,6 +27,7 @@ type EndpointInfo struct {
 	Status     bool
 	Latency    time.Duration
 	StableID   string
+	GroupName  string
 }
 
 func IndexHandler(version string, proxyChecker *checker.ProxyChecker) http.HandlerFunc {
@@ -44,22 +45,29 @@ func IndexHandler(version string, proxyChecker *checker.ProxyChecker) http.Handl
 		endpointsMu.RUnlock()
 
 		isPublic := config.CLIConfig.Web.Public
-		showServerDetails := config.CLIConfig.Web.ShowServerDetails
-		if isPublic {
-			showServerDetails = false
-		}
+		showServerDetails := shouldShowServerDetails()
 
 		endpoints := allEndpoints
 		if isPublic {
+			// In public mode the per-proxy config URL (copy link) is never
+			// exposed. Server address/port are exposed only when details are
+			// allowed, e.g. via WEB_TRUSTED_EXTERNAL_AUTH behind an external
+			// auth proxy.
 			endpoints = make([]EndpointInfo, len(allEndpoints))
 			for i, ep := range allEndpoints {
-				endpoints[i] = EndpointInfo{
-					Name:     ep.Name,
-					Index:    ep.Index,
-					Status:   ep.Status,
-					Latency:  ep.Latency,
-					StableID: ep.StableID,
+				e := EndpointInfo{
+					Name:      ep.Name,
+					Index:     ep.Index,
+					Status:    ep.Status,
+					Latency:   ep.Latency,
+					StableID:  ep.StableID,
+					GroupName: ep.GroupName,
 				}
+				if showServerDetails {
+					e.ServerInfo = ep.ServerInfo
+					e.ProxyPort = ep.ProxyPort
+				}
+				endpoints[i] = e
 			}
 		}
 
@@ -170,6 +178,7 @@ func RegisterConfigEndpoints(proxies []*models.ProxyConfig, proxyChecker *checke
 			Status:     status,
 			Latency:    latency,
 			StableID:   proxy.StableID,
+			GroupName:  proxy.GroupName,
 		})
 	}
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -110,6 +110,9 @@
         background: var(--bg-tertiary);
         border: 1px solid var(--border);
       }
+      .group-header:hover {
+        border-color: var(--border-hover);
+      }
 
       .text-primary {
         color: var(--text-primary);
@@ -856,84 +859,112 @@
         x-show="showProxies"
         class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 mb-4"
       >
-        <template x-for="(proxy, idx) in filteredProxies" :key="proxy.stableId">
-          <div
-            class="proxy-card group card rounded-lg px-3 py-2.5 flex items-center gap-3 transition-all duration-150"
-            :class="initialLoad && 'animate'"
-          >
-            <!-- Status dot -->
-            <div class="relative flex-shrink-0">
-              <div
-                class="w-2 h-2 rounded-full"
-                :class="proxy.status ? 'status-online pulse' : 'status-offline'"
-              ></div>
-            </div>
-
-            <!-- Info -->
-            <div class="flex-1 min-w-0">
-              {{ if .IsPublic }}
-              <span
-                class="text-sm text-primary truncate block"
-                x-text="proxy.name"
-              ></span>
-              {{ else }}
-              <a
-                :href="proxy.url"
-                target="_blank"
-                class="text-sm text-primary link-hover truncate block transition-colors"
-                x-text="proxy.name"
-              ></a>
-              {{ end }} {{ if .ShowServerDetails }}
-              <span class="text-xs text-muted truncate block"
-                ><span x-text="proxy.serverInfo"></span> · :<span
-                  x-text="proxy.proxyPort"
-                ></span
-              ></span>
-              {{ end }}
-            </div>
-
-            <!-- Latency -->
-            <div class="flex flex-col items-center gap-1 flex-shrink-0">
-              <span
-                class="text-xs tabular-nums"
-                :class="proxy.latencyMs === 0 ? 'text-muted' : proxy.latencyMs < 500 ? 'latency-good' : proxy.latencyMs < 1000 ? 'latency-medium' : 'latency-bad'"
-                x-text="proxy.latency"
-              ></span>
-              <div class="flex items-center gap-0.5">
-                <template x-for="i in 5" :key="i">
-                  <div
-                    class="latency-segment"
-                    :class="proxy.latencyMs === 0 ? '' :
-                    (proxy.latencyMs < 500 ? (i <= getSegments(proxy.latencyMs) ? 'segment-good' : '') :
-                     proxy.latencyMs < 1000 ? (i <= getSegments(proxy.latencyMs) ? 'segment-medium' : '') :
-                     (i <= getSegments(proxy.latencyMs) ? 'segment-bad' : ''))"
-                  ></div>
-                </template>
-              </div>
-            </div>
-
-            {{ if not .IsPublic }}
-            <!-- Copy -->
-            <button
-              @click="copyUrl(proxy)"
-              class="hidden sm:block p-1.5 rounded text-muted btn-icon transition-all"
-              title="Copy URL"
-            >
-              <svg
-                class="w-3.5 h-3.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+        <template x-for="item in displayItems" :key="item.key">
+          <div :style="item.type === 'header' ? 'grid-column: 1 / -1' : ''">
+            <!-- Group header (balancer groups) -->
+            <template x-if="item.type === 'header'">
+              <button
+                @click="toggleGroup(item.block.group)"
+                class="group-header card-flat w-full flex items-center gap-2 px-3 py-2.5 rounded-lg text-left transition-colors"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                />
-              </svg>
-            </button>
-            {{ end }}
+                <svg
+                  class="w-3.5 h-3.5 text-muted transition-transform flex-shrink-0"
+                  :class="collapsedGroups[item.block.group] && '-rotate-90'"
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+                <span class="text-sm font-medium text-primary truncate flex-1" x-text="item.block.group"></span>
+                <span class="text-xs text-muted tabular-nums flex-shrink-0"
+                  ><span
+                    :class="item.block.online === item.block.total ? 'latency-good' : (item.block.online === 0 ? 'latency-bad' : '')"
+                    x-text="item.block.online"
+                  ></span>/<span x-text="item.block.total"></span
+                ></span>
+              </button>
+            </template>
+
+            <!-- Proxy card -->
+            <template x-if="item.type === 'proxy'">
+              <div
+                class="proxy-card group card rounded-lg px-3 py-2.5 flex items-center gap-3 transition-all duration-150"
+                :class="initialLoad && 'animate'"
+              >
+                <!-- Status dot -->
+                <div class="relative flex-shrink-0">
+                  <div
+                    class="w-2 h-2 rounded-full"
+                    :class="item.proxy.status ? 'status-online pulse' : 'status-offline'"
+                  ></div>
+                </div>
+
+                <!-- Info -->
+                <div class="flex-1 min-w-0">
+                  {{ if .IsPublic }}
+                  <span
+                    class="text-sm text-primary truncate block"
+                    x-text="item.proxy.name"
+                  ></span>
+                  {{ else }}
+                  <a
+                    :href="item.proxy.url"
+                    target="_blank"
+                    class="text-sm text-primary link-hover truncate block transition-colors"
+                    x-text="item.proxy.name"
+                  ></a>
+                  {{ end }} {{ if .ShowServerDetails }}
+                  <span class="text-xs text-muted truncate block"
+                    ><span x-text="item.proxy.serverInfo"></span> · :<span
+                      x-text="item.proxy.proxyPort"
+                    ></span
+                  ></span>
+                  {{ end }}
+                </div>
+
+                <!-- Latency -->
+                <div class="flex flex-col items-center gap-1 flex-shrink-0">
+                  <span
+                    class="text-xs tabular-nums"
+                    :class="item.proxy.latencyMs === 0 ? 'text-muted' : item.proxy.latencyMs < 500 ? 'latency-good' : item.proxy.latencyMs < 1000 ? 'latency-medium' : 'latency-bad'"
+                    x-text="item.proxy.latency"
+                  ></span>
+                  <div class="flex items-center gap-0.5">
+                    <template x-for="i in 5" :key="i">
+                      <div
+                        class="latency-segment"
+                        :class="item.proxy.latencyMs === 0 ? '' :
+                        (item.proxy.latencyMs < 500 ? (i <= getSegments(item.proxy.latencyMs) ? 'segment-good' : '') :
+                         item.proxy.latencyMs < 1000 ? (i <= getSegments(item.proxy.latencyMs) ? 'segment-medium' : '') :
+                         (i <= getSegments(item.proxy.latencyMs) ? 'segment-bad' : ''))"
+                      ></div>
+                    </template>
+                  </div>
+                </div>
+
+                {{ if not .IsPublic }}
+                <!-- Copy -->
+                <button
+                  @click="copyUrl(item.proxy)"
+                  class="hidden sm:block p-1.5 rounded text-muted btn-icon transition-all"
+                  title="Copy URL"
+                >
+                  <svg
+                    class="w-3.5 h-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                    />
+                  </svg>
+                </button>
+                {{ end }}
+              </div>
+            </template>
           </div>
         </template>
       </div>
@@ -1065,9 +1096,11 @@
             return classes.join(' ');
           },
 
+          collapsedGroups: {},
+
           proxies: [
             {{ range $.Endpoints }}
-            { name: "{{.Name}}", stableId: "{{.StableID}}", {{ if $.ShowServerDetails }}serverInfo: "{{.ServerInfo}}", proxyPort: {{.ProxyPort}}, {{ end }}{{ if not $.IsPublic }}url: "{{.URL}}", {{ end }}index: {{.Index}}, status: {{.Status}}, latency: "{{ formatLatency .Latency }}", latencyMs: {{ .Latency.Milliseconds }} },
+            { name: "{{.Name}}", stableId: "{{.StableID}}", groupName: "{{.GroupName}}", {{ if $.ShowServerDetails }}serverInfo: "{{.ServerInfo}}", proxyPort: {{.ProxyPort}}, {{ end }}{{ if not $.IsPublic }}url: "{{.URL}}", {{ end }}index: {{.Index}}, status: {{.Status}}, latency: "{{ formatLatency .Latency }}", latencyMs: {{ .Latency.Milliseconds }} },
             {{ end }}
           ],
 
@@ -1108,6 +1141,60 @@
               if (this.sort === 'name') return this.stripLeadingEmoji(a.name).localeCompare(this.stripLeadingEmoji(b.name));
               return a.index - b.index;
             });
+          },
+
+          // Partition filteredProxies into render blocks: one block per balancer
+          // group (proxies that share a non-empty groupName) plus a final block for
+          // ungrouped proxies. Subscriptions without groups yield a single block,
+          // so the layout is unchanged for them.
+          get proxyBlocks() {
+            const groups = new Map();
+            const ungrouped = [];
+            for (const p of this.filteredProxies) {
+              if (p.groupName) {
+                if (!groups.has(p.groupName)) groups.set(p.groupName, []);
+                groups.get(p.groupName).push(p);
+              } else {
+                ungrouped.push(p);
+              }
+            }
+            const blocks = [];
+            // Ungrouped (standalone) nodes first so each balancer group below is
+            // clearly delimited by its own header (no blending into a headerless block).
+            if (ungrouped.length) {
+              blocks.push({ key: '_ungrouped', group: '', proxies: ungrouped, online: 0, total: ungrouped.length });
+            }
+            for (const [name, proxies] of groups) {
+              blocks.push({
+                key: 'g:' + name,
+                group: name,
+                proxies,
+                online: proxies.filter(p => p.status).length,
+                total: proxies.length,
+              });
+            }
+            return blocks;
+          },
+
+          // Flatten blocks into a single list of grid items (group header rows +
+          // proxy cards) so the whole grid shares one uniform gap. Collapsed groups
+          // contribute only their header.
+          get displayItems() {
+            const items = [];
+            for (const b of this.proxyBlocks) {
+              if (b.group) {
+                items.push({ type: 'header', key: 'h:' + b.group, block: b });
+                if (this.collapsedGroups[b.group]) continue;
+              }
+              for (const p of b.proxies) {
+                items.push({ type: 'proxy', key: p.stableId, proxy: p });
+              }
+            }
+            return items;
+          },
+
+          toggleGroup(name) {
+            this.collapsedGroups[name] = !this.collapsedGroups[name];
           },
 
           init() {

--- a/xray/config.go
+++ b/xray/config.go
@@ -1,12 +1,15 @@
 package xray
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"xray-checker/logger"
 	"xray-checker/models"
+
+	"github.com/xtls/xray-core/infra/conf/serial"
 )
 
 type ConfigGenerator struct{}
@@ -28,37 +31,94 @@ func (g *ConfigGenerator) GenerateConfig(proxies []*models.ProxyConfig, startPor
 	return json.MarshalIndent(config, "", "  ")
 }
 
-func (g *ConfigGenerator) GenerateAndSaveConfig(proxies []*models.ProxyConfig, startPort int, filename string, xrayLogLevel string) error {
-	configBytes, err := g.GenerateConfig(proxies, startPort, xrayLogLevel)
+// validateConfigBuild runs the generated JSON through xray-core's decode+build path
+// (the same path the runner uses at startup), so a config that xray-core would reject
+// is caught here — letting us report and prune the offending node instead of having
+// the whole instance abort on Start.
+func validateConfigBuild(configBytes []byte) error {
+	xrayConfig, err := serial.DecodeJSONConfig(bytes.NewReader(configBytes))
 	if err != nil {
-		return fmt.Errorf("error generating config: %v", err)
+		return err
 	}
-
-	if err := g.ValidateConfig(configBytes); err != nil {
-		logger.Warn("Config validation failed: %v", err)
-	}
-
-	if err := os.WriteFile(filename, configBytes, 0644); err != nil {
-		return fmt.Errorf("error saving config: %v", err)
-	}
-
-	return nil
+	_, err = xrayConfig.Build()
+	return err
 }
 
-func (g *ConfigGenerator) ValidateConfig(configBytes []byte) error {
-	var config map[string]interface{}
-	if err := json.Unmarshal(configBytes, &config); err != nil {
-		return fmt.Errorf("failed to parse config: %v", err)
-	}
+func outboundTag(proxy *models.ProxyConfig) string {
+	return fmt.Sprintf("%s_%d", proxy.Name, proxy.Index)
+}
 
-	required := []string{"inbounds", "outbounds", "routing"}
-	for _, field := range required {
-		if _, ok := config[field]; !ok {
-			return fmt.Errorf("missing required field: %s", field)
+// extractFailingOutboundTag pulls the outbound tag from an xray build error shaped
+// like: "... failed to build outbound config with tag <TAG> > <reason>".
+func extractFailingOutboundTag(errMsg string) string {
+	const marker = "with tag "
+	i := strings.Index(errMsg, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := errMsg[i+len(marker):]
+	if j := strings.Index(rest, " > "); j >= 0 {
+		return strings.TrimSpace(rest[:j])
+	}
+	return strings.TrimSpace(rest)
+}
+
+// shortBuildReason returns the leaf segment of xray's ">"-chained error message.
+func shortBuildReason(err error) string {
+	parts := strings.Split(err.Error(), " > ")
+	return strings.TrimSpace(parts[len(parts)-1])
+}
+
+// GenerateValidatedConfig generates the xray config and, if xray-core rejects a
+// specific outbound at build time, drops that proxy, logs why it was excluded, and
+// regenerates. This prevents a single unsupported/legacy node (e.g. a transport
+// field removed in a newer xray-core) from bringing down the whole instance. It
+// writes the final, buildable config to filename and returns the surviving proxies.
+func (g *ConfigGenerator) GenerateValidatedConfig(proxies []*models.ProxyConfig, startPort int, filename, xrayLogLevel string) ([]*models.ProxyConfig, error) {
+	current := proxies
+	for {
+		configBytes, err := g.GenerateConfig(current, startPort, xrayLogLevel)
+		if err != nil {
+			return current, fmt.Errorf("error generating config: %v", err)
 		}
-	}
 
-	return nil
+		buildErr := validateConfigBuild(configBytes)
+		if buildErr == nil {
+			if err := os.WriteFile(filename, configBytes, 0644); err != nil {
+				return current, fmt.Errorf("error saving config: %v", err)
+			}
+			if len(current) != len(proxies) {
+				logger.Warn("Config validated after excluding %d unbuildable prox(ies); %d remain", len(proxies)-len(current), len(current))
+			}
+			return current, nil
+		}
+
+		tag := extractFailingOutboundTag(buildErr.Error())
+		idx := -1
+		if tag != "" {
+			for i, p := range current {
+				if outboundTag(p) == tag {
+					idx = i
+					break
+				}
+			}
+		}
+
+		if idx < 0 {
+			// Failure can't be attributed to a single proxy — keep the config so the
+			// error surfaces at startup instead of silently dropping everything.
+			logger.Error("Xray config build failed and no offending proxy could be identified; keeping config as-is: %v", buildErr)
+			if werr := os.WriteFile(filename, configBytes, 0644); werr != nil {
+				return current, werr
+			}
+			return current, nil
+		}
+
+		bad := current[idx]
+		logger.Warn("Excluding proxy %q (%s %s:%d): xray rejected its config: %s",
+			bad.Name, bad.Protocol, bad.Server, bad.Port, shortBuildReason(buildErr))
+		current = append(current[:idx:idx], current[idx+1:]...)
+	}
 }
 
 func (g *ConfigGenerator) generateInbounds(proxies []*models.ProxyConfig, startPort int) []map[string]interface{} {
@@ -108,6 +168,13 @@ func (g *ConfigGenerator) generateOutbounds(proxies []*models.ProxyConfig) []map
 	}
 
 	return outbounds
+}
+
+// GenerateProxyOutbound returns the xray outbound configuration map for a single
+// proxy. It is exported so the web layer can surface a sanitized view of the
+// generated config for debugging without rebuilding the whole config.
+func (g *ConfigGenerator) GenerateProxyOutbound(proxy *models.ProxyConfig) map[string]interface{} {
+	return g.generateProxyOutbound(proxy)
 }
 
 func (g *ConfigGenerator) generateProxyOutbound(proxy *models.ProxyConfig) map[string]interface{} {
@@ -268,6 +335,19 @@ func (g *ConfigGenerator) generateStreamSettings(proxy *models.ProxyConfig) map[
 		ss["grpcSettings"] = map[string]interface{}{
 			"serviceName": proxy.GetServiceName(),
 			"multiMode":   proxy.MultiMode,
+		}
+
+	case "kcp", "mkcp":
+		if proxy.RawKcpSettings != "" {
+			var rawSettings map[string]interface{}
+			if err := json.Unmarshal([]byte(proxy.RawKcpSettings), &rawSettings); err == nil {
+				// xray-core removed kcp "header" and "seed" (migrated to finalmask).
+				// Emitting them aborts the WHOLE config build, taking every proxy
+				// down, so drop them — the node degrades to plain mKCP instead.
+				delete(rawSettings, "header")
+				delete(rawSettings, "seed")
+				ss["kcpSettings"] = rawSettings
+			}
 		}
 
 	case "http", "h2":

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -3,12 +3,56 @@ package xray
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"xray-checker/models"
 
 	"github.com/xtls/xray-core/infra/conf/serial"
 )
+
+func TestExtractFailingOutboundTag(t *testing.T) {
+	cases := map[string]string{
+		"infra/conf: failed to build outbound config with tag BAD-xhttp_1 > infra/conf: unsupported mode: x": "BAD-xhttp_1",
+		"failed to build outbound config with tag My Server | node_7 > some reason":                          "My Server | node_7",
+		"some unrelated error":   "",
+		"with tag trailing-only": "trailing-only",
+	}
+	for in, want := range cases {
+		if got := extractFailingOutboundTag(in); got != want {
+			t.Errorf("extractFailingOutboundTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A single unbuildable proxy must be excluded (with the rest kept) rather than
+// aborting the whole config.
+func TestGenerateValidatedConfigPrunesUnbuildable(t *testing.T) {
+	good := &models.ProxyConfig{
+		Protocol: "vless", Server: "good.example.com", Port: 443, Name: "good",
+		UUID: "00000000-0000-0000-0000-000000000000", Type: "tcp", Security: "none", Index: 0,
+	}
+	bad := &models.ProxyConfig{
+		Protocol: "vless", Server: "bad.example.com", Port: 443, Name: "bad",
+		UUID: "00000000-0000-0000-0000-000000000000", Type: "xhttp", Security: "tls", SNI: "bad.example.com",
+		RawXhttpSettings: `{"mode":"bogus-mode","path":"/"}`, Index: 1,
+	}
+
+	f := filepath.Join(t.TempDir(), "cfg.json")
+	g := NewConfigGenerator()
+	survivors, err := g.GenerateValidatedConfig([]*models.ProxyConfig{good, bad}, 20000, f, "none")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(survivors) != 1 || survivors[0].Name != "good" {
+		t.Fatalf("expected only 'good' to survive, got %d proxies", len(survivors))
+	}
+	data, _ := os.ReadFile(f)
+	if err := validateConfigBuild(data); err != nil {
+		t.Fatalf("written config must be buildable, got: %v", err)
+	}
+}
 
 // buildsWithXrayCore feeds a generated config through the exact decode+build path
 // that xray/runner.go uses at startup. This validates the JSON against xray-core's


### PR DESCRIPTION
## Summary
Builds on #145 and #156 to add first-class JSON (Remnawave-style) subscriptions,
a grouped dashboard, broader Xray transport handling, and config robustness.

### Subscriptions
- `SUBSCRIPTION_JSON_FORMAT` — fetch a subscription as Xray JSON and expand
  balancer / `leastPing` outbounds into individually checkable proxies, so each
  node in a balancer group is tracked separately
- `SUBSCRIPTION_USER_AGENT` and `SUBSCRIPTION_HEADERS` for custom request headers
- Proxies grouped by subscription / balancer, carrying a group name

### Dashboard & metrics
- New `group_name` metric label and a grouped, collapsible dashboard view
- `WEB_TRUSTED_EXTERNAL_AUTH` — allow server details in public mode when the
  dashboard sits behind an external auth proxy; all detail gating now routes
  through a single `shouldShowServerDetails` helper
- API can expose a **sanitized** generated config per proxy (uuid/password/auth/
  kcp seed masked, public reality material kept) behind `WEB_SHOW_DETAILS`

### Xray config
- Pass through kcp / xhttp stream settings (incl. xhttp-over-GET); strip removed
  mkcp `header` / `seed` fields for current xray-core
- **validate-and-prune**: a proxy whose config fails to build is dropped and
  logged clearly instead of failing the whole instance

### Supersedes
- #145 — JSON balancer configs with individual node tracking (@AirP0WeR)
- #156 — JSON subscriptions, grouped UI, Xray config handling (@4erdenko)

## Testing
- Unit tests: sanitizer/gating, stable IDs, config build, naming, prune
- Verified end-to-end against multiple live JSON + base64 subscriptions
