### PR TITLE
fix(web): make hideBackground=true actually transparent (#147)

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,11 +1,10 @@
 {{ define "index.html" }}
 <!DOCTYPE html>
-<html lang="en" x-data="dashboard()" :class="{ 'light': !darkMode }" x-cloak>
+<html lang="en" x-data="dashboard()" :class="{ 'light': !darkMode, 'no-bg': hideBackground }" x-cloak>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
-    <meta name="color-scheme" content="dark only" />
     <title>
       {{ if and .IsPublic .SubscriptionName }}{{ .SubscriptionName }}{{ else
       }}Xray Checker{{ end }}
@@ -88,6 +87,17 @@
         --filter-offline-bg: rgba(255, 0, 0, 0.15);
         --btn-active-bg: rgba(0, 166, 61, 0.1);
         --btn-active-border: rgba(0, 166, 61, 0.3);
+      }
+
+      /* color-scheme drives native controls/scrollbars. Set via CSS (not a
+         forced `dark only` meta) so the transparent embed below can override it
+         to `normal` — a forced scheme makes the browser paint an opaque canvas
+         and breaks hideBackground=true transparency in an iframe. */
+      html {
+        color-scheme: dark;
+      }
+      html.light {
+        color-scheme: light;
       }
 
       body {
@@ -380,9 +390,17 @@
         background: var(--color-red);
       }
 
-      /* Transparent background */
+      /* Transparent background (for embedding in an iframe).
+         Applied to both <html> and <body>: the body's background alone is not
+         enough because the page forces `color-scheme: dark only`, which makes the
+         browser paint an opaque dark canvas behind a transparent body. Dropping
+         the forced scheme on the root lets the transparent root compose over the
+         parent page. */
       .no-bg {
         background: transparent !important;
+      }
+      html.no-bg {
+        color-scheme: normal;
       }
 
       /* Badge mode */

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -391,11 +391,11 @@
       }
 
       /* Transparent background (for embedding in an iframe).
-         Applied to both <html> and <body>: the body's background alone is not
-         enough because the page forces `color-scheme: dark only`, which makes the
-         browser paint an opaque dark canvas behind a transparent body. Dropping
-         the forced scheme on the root lets the transparent root compose over the
-         parent page. */
+         Applied to both <html> and <body>, and paired with `color-scheme:
+         normal` on the root below: a transparent body alone is not enough,
+         because a non-normal color-scheme makes the browser paint an opaque
+         canvas behind it. Neutralizing the scheme on the root lets the
+         transparent document compose over the parent page. */
       .no-bg {
         background: transparent !important;
       }


### PR DESCRIPTION
## Problem

`?hideBackground=true` is documented to make the dashboard background transparent for iframe embedding, but the background stayed dark on any theme — the embedded page showed an opaque dark area instead of the host page behind it.

## Cause

The page forced `<meta name="color-scheme" content="dark only">`. The `only` keyword makes the browser paint an opaque dark **canvas** (viewport backdrop) even when `html`/`body` backgrounds are transparent, which defeats iframe transparency. A CSS `color-scheme` override doesn't beat the forced meta.

## Fix

- Drop the forced `dark only` meta.
- Drive `color-scheme` from CSS instead (`html { dark }`, `html.light { light }`) so native controls/scrollbars look the same as before, but the value can be overridden.
- Apply `.no-bg` to `<html>` as well as `<body>`, and add `html.no-bg { color-scheme: normal }`. With no forced scheme and a transparent root, the document composes over the parent page.

## Testing

Embedded the dashboard in an iframe over a colored parent page:

- `hideBackground=true` → background is now transparent (the parent shows through; only the cards render).
- Normal dashboard (dark theme) → unchanged.
- Light theme → unchanged.
