### PR TITLE
feat(config): add xray-interface option for binding proxy connections to a network interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ type CLI struct {
 	Xray struct {
 		StartPort int    `name:"xray-start-port" help:"Start port for proxy configuration" default:"10000" env:"XRAY_START_PORT"`
 		LogLevel  string `name:"xray-log-level" help:"Xray log level (debug|info|warning|error|none)" default:"none" env:"XRAY_LOG_LEVEL"`
+		Interface string `name:"xray-interface" help:"Network interface used for Xray proxy connections (for example wwan0)" default:"" env:"XRAY_INTERFACE"`
 	} `embed:"" prefix:""`
 
 	Metrics struct {

--- a/docs/src/content/docs/configuration/envs.md
+++ b/docs/src/content/docs/configuration/envs.md
@@ -250,6 +250,18 @@ Starting port number for SOCKS5 proxies. Each proxy will use sequential ports st
 
 Controls Xray Core logging verbosity.
 
+### XRAY_INTERFACE
+
+- CLI: `--xray-interface`
+- Required: No
+- Default: None
+
+Binds Xray proxy connections to a network interface, for example `wwan0` or
+`eth2`. This is useful on multi-WAN and multi-modem routers. The value must be
+the operating-system device name visible to the xray-checker process. When
+running in a container, use host networking or otherwise expose the interface
+inside the container.
+
 ## Metrics
 
 ### METRICS_HOST

--- a/docs/src/content/docs/configuration/envs.md
+++ b/docs/src/content/docs/configuration/envs.md
@@ -260,7 +260,8 @@ Binds Xray proxy connections to a network interface, for example `wwan0` or
 `eth2`. This is useful on multi-WAN and multi-modem routers. The value must be
 the operating-system device name visible to the xray-checker process. When
 running in a container, use host networking or otherwise expose the interface
-inside the container.
+inside the container. For WireGuard proxies, the setting binds the UDP peer
+socket while the checker keeps the tunnel in userspace.
 
 ## Metrics
 

--- a/docs/src/content/docs/usage/cli.md
+++ b/docs/src/content/docs/usage/cli.md
@@ -73,6 +73,7 @@ All proxies from all subscriptions will be combined and monitored together.
   --simulate-latency=true \
   --xray-start-port=10000 \
   --xray-log-level=none \
+  --xray-interface="" \
   --metrics-host=0.0.0.0 \
   --metrics-port=2112 \
   --metrics-protected=true \

--- a/docs/src/content/docs/usage/docker.md
+++ b/docs/src/content/docs/usage/docker.md
@@ -62,6 +62,7 @@ docker run -d \
   -e SIMULATE_LATENCY=true \
   -e XRAY_START_PORT=10000 \
   -e XRAY_LOG_LEVEL=none \
+  -e XRAY_INTERFACE="" \
   -e METRICS_HOST=0.0.0.0 \
   -e METRICS_PORT=2112 \
   -e METRICS_PROTECTED=true \

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ func main() {
 	if logLevel == logger.LevelNone {
 		logger.Startup("Log level: none (silent mode)")
 	}
+	if config.CLIConfig.Xray.Interface != "" {
+		logger.Info("Binding Xray proxy connections to interface %s", config.CLIConfig.Xray.Interface)
+	}
 
 	if err := web.InitAssetLoader(config.CLIConfig.Web.CustomAssetsPath); err != nil {
 		logger.Fatal("Failed to initialize custom assets: %v", err)
@@ -250,7 +253,7 @@ func updateConfiguration(newConfigs []*models.ProxyConfig, currentConfigs *[]*mo
 	xray.PrepareProxyConfigs(newConfigs)
 
 	configFile := "xray_config.json"
-	configGenerator := xray.NewConfigGenerator()
+	configGenerator := xray.NewConfigGenerator(config.CLIConfig.Xray.Interface)
 	validProxies, err := configGenerator.GenerateValidatedConfig(
 		newConfigs,
 		config.CLIConfig.Xray.StartPort,

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -52,7 +52,7 @@ func InitializeConfiguration(configFile string, version string) (*[]*models.Prox
 
 	xray.PrepareProxyConfigs(proxyConfigs)
 
-	configGenerator := xray.NewConfigGenerator()
+	configGenerator := xray.NewConfigGenerator(config.CLIConfig.Xray.Interface)
 	validProxies, err := configGenerator.GenerateValidatedConfig(
 		proxyConfigs,
 		config.CLIConfig.Xray.StartPort,

--- a/web/api.go
+++ b/web/api.go
@@ -54,6 +54,7 @@ type ConfigResponse struct {
 	CheckMethod                string   `json:"checkMethod"`
 	Timeout                    int      `json:"timeout"`
 	StartPort                  int      `json:"startPort"`
+	XrayInterface              string   `json:"xrayInterface,omitempty"`
 	SubscriptionUpdate         bool     `json:"subscriptionUpdate"`
 	SubscriptionUpdateInterval int      `json:"subscriptionUpdateInterval"`
 	SimulateLatency            bool     `json:"simulateLatency"`
@@ -111,7 +112,7 @@ func toProxyInfo(proxy *models.ProxyConfig, online bool, latency time.Duration, 
 		MetricsLabels: proxy.MetricsLabels,
 	}
 	if includeDetails {
-		outbound := xray.NewConfigGenerator().GenerateProxyOutbound(proxy)
+		outbound := xray.NewConfigGenerator(config.CLIConfig.Xray.Interface).GenerateProxyOutbound(proxy)
 		info.GeneratedConfig = sanitizeGeneratedConfig(outbound)
 	}
 	return info
@@ -339,6 +340,7 @@ func APIConfigHandler(proxyChecker *checker.ProxyChecker) http.HandlerFunc {
 			CheckMethod:                config.CLIConfig.Proxy.CheckMethod,
 			Timeout:                    config.CLIConfig.Proxy.Timeout,
 			StartPort:                  config.CLIConfig.Xray.StartPort,
+			XrayInterface:              config.CLIConfig.Xray.Interface,
 			SubscriptionUpdate:         config.CLIConfig.Subscription.Update,
 			SubscriptionUpdateInterval: config.CLIConfig.Subscription.UpdateInterval,
 			SimulateLatency:            config.CLIConfig.Proxy.SimulateLatency,

--- a/web/openapi.yaml
+++ b/web/openapi.yaml
@@ -309,6 +309,10 @@ components:
         startPort:
           type: integer
           example: 10000
+        xrayInterface:
+          type: string
+          description: Network interface used for Xray proxy connections
+          example: "wwan0"
         subscriptionUpdate:
           type: boolean
           example: true
@@ -348,4 +352,3 @@ components:
         ip:
           type: string
           example: "203.0.113.1"
-

--- a/xray/config.go
+++ b/xray/config.go
@@ -299,6 +299,11 @@ func (g *ConfigGenerator) generateProxyOutbound(proxy *models.ProxyConfig) map[s
 			"secretKey": proxy.WGPrivateKey,
 			"address":   proxy.WGAddresses,
 			"peers":     []map[string]interface{}{peer},
+			// A health checker does not need a host kernel TUN. Keeping WireGuard
+			// userspace-only avoids changing host interfaces, routes, or sysctls
+			// when xray-checker runs with CAP_NET_ADMIN (for example as root on
+			// OpenWrt).
+			"noKernelTun": true,
 		}
 		if proxy.WGMTU > 0 {
 			settings["mtu"] = proxy.WGMTU
@@ -306,8 +311,14 @@ func (g *ConfigGenerator) generateProxyOutbound(proxy *models.ProxyConfig) map[s
 		outbound["settings"] = settings
 	}
 
-	// WireGuard is its own transport and takes no streamSettings.
-	if proxy.Protocol != "wireguard" {
+	if proxy.Protocol == "wireguard" {
+		// WireGuard does not use a stream transport/security method, but Xray's
+		// WireGuard client consumes streamSettings.sockopt for the UDP socket it
+		// opens to the peer endpoint.
+		if g.outboundInterface != "" {
+			outbound["streamSettings"] = g.generateSocketSettings()
+		}
+	} else {
 		outbound["streamSettings"] = g.generateStreamSettings(proxy)
 	}
 
@@ -338,9 +349,7 @@ func (g *ConfigGenerator) generateStreamSettings(proxy *models.ProxyConfig) map[
 		"security": security,
 	}
 	if g.outboundInterface != "" {
-		ss["sockopt"] = map[string]interface{}{
-			"interface": g.outboundInterface,
-		}
+		ss["sockopt"] = g.generateSocketOptions()
 	}
 
 	if security == "tls" {
@@ -527,6 +536,18 @@ func (g *ConfigGenerator) generateStreamSettings(proxy *models.ProxyConfig) map[
 	}
 
 	return ss
+}
+
+func (g *ConfigGenerator) generateSocketSettings() map[string]interface{} {
+	return map[string]interface{}{
+		"sockopt": g.generateSocketOptions(),
+	}
+}
+
+func (g *ConfigGenerator) generateSocketOptions() map[string]interface{} {
+	return map[string]interface{}{
+		"interface": g.outboundInterface,
+	}
 }
 
 func (g *ConfigGenerator) generateRouting(proxies []*models.ProxyConfig) map[string]interface{} {

--- a/xray/config.go
+++ b/xray/config.go
@@ -12,10 +12,18 @@ import (
 	"github.com/xtls/xray-core/infra/conf/serial"
 )
 
-type ConfigGenerator struct{}
+type ConfigGenerator struct {
+	outboundInterface string
+}
 
-func NewConfigGenerator() *ConfigGenerator {
-	return &ConfigGenerator{}
+func NewConfigGenerator(outboundInterfaces ...string) *ConfigGenerator {
+	var outboundInterface string
+	if len(outboundInterfaces) > 0 {
+		outboundInterface = strings.TrimSpace(outboundInterfaces[0])
+	}
+	return &ConfigGenerator{
+		outboundInterface: outboundInterface,
+	}
 }
 
 func (g *ConfigGenerator) GenerateConfig(proxies []*models.ProxyConfig, startPort int, xrayLogLevel string) ([]byte, error) {
@@ -328,6 +336,11 @@ func (g *ConfigGenerator) generateStreamSettings(proxy *models.ProxyConfig) map[
 	ss := map[string]interface{}{
 		"network":  network,
 		"security": security,
+	}
+	if g.outboundInterface != "" {
+		ss["sockopt"] = map[string]interface{}{
+			"interface": g.outboundInterface,
+		}
 	}
 
 	if security == "tls" {

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -60,7 +60,7 @@ func TestGenerateValidatedConfigPrunesUnbuildable(t *testing.T) {
 // silently ignore at runtime.
 func buildsWithXrayCore(t *testing.T, proxies []*models.ProxyConfig) []byte {
 	t.Helper()
-	g := NewConfigGenerator()
+	g := NewConfigGenerator("")
 	configBytes, err := g.GenerateConfig(proxies, 10000, "none")
 	if err != nil {
 		t.Fatalf("GenerateConfig failed: %v", err)
@@ -182,6 +182,58 @@ func TestGenerateVlessConfigStillBuilds(t *testing.T) {
 		Index:     0,
 	}
 	buildsWithXrayCore(t, []*models.ProxyConfig{proxy})
+}
+
+func TestGenerateConfigBindsProxyOutboundToInterface(t *testing.T) {
+	proxy := &models.ProxyConfig{
+		Protocol: "vless",
+		Server:   "example.com",
+		Port:     443,
+		Name:     "bound-vless",
+		UUID:     "00000000-0000-0000-0000-000000000000",
+		Type:     "tcp",
+		Security: "none",
+		Index:    0,
+	}
+
+	g := NewConfigGenerator("  wwan1  ")
+	configBytes, err := g.GenerateConfig([]*models.ProxyConfig{proxy}, 10000, "none")
+	if err != nil {
+		t.Fatalf("GenerateConfig failed: %v", err)
+	}
+	if err := validateConfigBuild(configBytes); err != nil {
+		t.Fatalf("xray-core rejected interface-bound config: %v\nconfig:\n%s", err, configBytes)
+	}
+
+	ss := streamSettingsOf(t, configBytes)
+	var sockopt struct {
+		Interface string `json:"interface"`
+	}
+	if err := json.Unmarshal(ss["sockopt"], &sockopt); err != nil {
+		t.Fatalf("failed to parse streamSettings.sockopt: %v", err)
+	}
+	if sockopt.Interface != "wwan1" {
+		t.Errorf("sockopt.interface = %q, want %q", sockopt.Interface, "wwan1")
+	}
+}
+
+func TestGenerateConfigOmitsSockoptWithoutInterface(t *testing.T) {
+	proxy := &models.ProxyConfig{
+		Protocol: "vless",
+		Server:   "example.com",
+		Port:     443,
+		Name:     "unbound-vless",
+		UUID:     "00000000-0000-0000-0000-000000000000",
+		Type:     "tcp",
+		Security: "none",
+		Index:    0,
+	}
+
+	configBytes := buildsWithXrayCore(t, []*models.ProxyConfig{proxy})
+	ss := streamSettingsOf(t, configBytes)
+	if _, ok := ss["sockopt"]; ok {
+		t.Error("streamSettings.sockopt must be omitted when XRAY_INTERFACE is empty")
+	}
 }
 
 func TestGenerateSocksHttpConfigsBuild(t *testing.T) {

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -326,10 +326,13 @@ func TestGenerateWireGuardConfigBuild(t *testing.T) {
 		}
 		found = true
 		if ob.StreamSettings != nil {
-			t.Errorf("wireguard outbound must not carry streamSettings")
+			t.Errorf("wireguard outbound without XRAY_INTERFACE must not carry streamSettings")
 		}
 		if _, hasAwg := ob.Settings["awg"]; hasAwg {
 			t.Errorf("plain wireguard must not emit an awg block (stock xray-core)")
+		}
+		if noKernelTun, ok := ob.Settings["noKernelTun"].(bool); !ok || !noKernelTun {
+			t.Errorf("wireguard must use userspace TUN, got noKernelTun=%v", ob.Settings["noKernelTun"])
 		}
 		if ob.Settings["secretKey"] == nil || ob.Settings["peers"] == nil {
 			t.Errorf("wireguard settings missing secretKey/peers: %v", ob.Settings)
@@ -337,5 +340,41 @@ func TestGenerateWireGuardConfigBuild(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected a wireguard outbound")
+	}
+}
+
+func TestGenerateWireGuardConfigBindsPeerSocketToInterface(t *testing.T) {
+	wg := &models.ProxyConfig{
+		Protocol: "wireguard", Name: "wg-bound", Server: "1.1.1.1", Port: 51820, Index: 0,
+		WGPrivateKey:    "WBkVvO3vdhF9VOaSokEQPSLpGQajKi2fpwKLODlySmk=",
+		WGPeerPublicKey: "xBsu74OtcatjpRMfW58muk/95FkaiSSYbZeM+6bRZ1Y=",
+		WGAddresses:     []string{"10.0.0.2/32"},
+		WGAllowedIPs:    []string{"0.0.0.0/0", "::/0"},
+	}
+
+	g := NewConfigGenerator("phy1-sta0")
+	configBytes, err := g.GenerateConfig([]*models.ProxyConfig{wg}, 10000, "none")
+	if err != nil {
+		t.Fatalf("GenerateConfig failed: %v", err)
+	}
+	if err := validateConfigBuild(configBytes); err != nil {
+		t.Fatalf("xray-core rejected interface-bound WireGuard config: %v\nconfig:\n%s", err, configBytes)
+	}
+
+	ss := streamSettingsOf(t, configBytes)
+	if _, ok := ss["network"]; ok {
+		t.Error("WireGuard streamSettings must be sockopt-only; network is protocol-managed")
+	}
+	if _, ok := ss["security"]; ok {
+		t.Error("WireGuard streamSettings must be sockopt-only; security is protocol-managed")
+	}
+	var sockopt struct {
+		Interface string `json:"interface"`
+	}
+	if err := json.Unmarshal(ss["sockopt"], &sockopt); err != nil {
+		t.Fatalf("failed to parse WireGuard streamSettings.sockopt: %v", err)
+	}
+	if sockopt.Interface != "phy1-sta0" {
+		t.Errorf("WireGuard sockopt.interface = %q, want %q", sockopt.Interface, "phy1-sta0")
 	}
 }


### PR DESCRIPTION
## Description of Changes

New option called xray-interface, so we can now monitor from different interfaces from router, if multiple WAN's present

## Type of Changes

<!-- Check applicable items -->

- [ ] Bug fix
- [X] New feature
- [X] Documentation improvement
- [ ] Performance optimization
- [ ] Other: <!-- specify type -->

## Related Issues

<!-- List related issues if any -->

Fixes #

## Checklist

- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I have tested changes locally
